### PR TITLE
feat(repos/ansible): add calibration_tools setup

### DIFF
--- a/ansible/roles/calibration_tools/README.md
+++ b/ansible/roles/calibration_tools/README.md
@@ -1,0 +1,1 @@
+# Calibration Tools

--- a/ansible/roles/calibration_tools/defaults/main.yaml
+++ b/ansible/roles/calibration_tools/defaults/main.yaml
@@ -1,0 +1,3 @@
+pyside2_url_base: https://github.com/hiroyuki-s1/PySide2InstallForJetson/raw/main/dist
+pyside2_wheel: PySide2-5.9.0a1-5.9.5-cp36-cp36m-linux_aarch64.whl
+pyside2_download_dir: /tmp

--- a/ansible/roles/calibration_tools/tasks/main.yaml
+++ b/ansible/roles/calibration_tools/tasks/main.yaml
@@ -7,8 +7,8 @@
 - name: Install dependencies
   pip:
     name:
-    - dt-apriltags
-    - ruamel.yaml
+      - dt-apriltags
+      - ruamel.yaml
     executable: pip3.6
     state: latest
 

--- a/ansible/roles/calibration_tools/tasks/main.yaml
+++ b/ansible/roles/calibration_tools/tasks/main.yaml
@@ -1,0 +1,25 @@
+- name: Upgrade pip
+  pip:
+    name: pip
+    executable: pip3.6
+    state: latest
+
+- name: Install dependencies
+  pip:
+    name:
+    - dt-apriltags
+    - ruamel.yaml
+    executable: pip3.6
+    state: latest
+
+- name: Download PySide2 wheel
+  ansible.builtin.uri:
+    url: "{{ pyside2_url_base }}/{{ pyside2_wheel }}"
+    dest: "{{ pyside2_download_dir }}/{{ pyside2_wheel }}"
+    mode: 0644
+
+- name: Install PySide2
+  pip:
+    name: "{{ pyside2_download_dir }}/{{ pyside2_wheel }}"
+    executable: pip3.6
+    state: latest

--- a/ansible/roles/calibration_tools/tasks/main.yaml
+++ b/ansible/roles/calibration_tools/tasks/main.yaml
@@ -1,7 +1,10 @@
+- name: Fix python interpreter version to 3
+  set_fact:
+    ansible_python_interpreter: /usr/bin/python3.6
+
 - name: Upgrade pip
   pip:
     name: pip
-    executable: pip3.6
     state: latest
 
 - name: Install dependencies
@@ -9,7 +12,6 @@
     name:
       - dt-apriltags
       - ruamel.yaml
-    executable: pip3.6
     state: latest
 
 - name: Download PySide2 wheel
@@ -21,5 +23,4 @@
 - name: Install PySide2
   pip:
     name: "{{ pyside2_download_dir }}/{{ pyside2_wheel }}"
-    executable: pip3.6
     state: latest

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -13,6 +13,7 @@
     - role: cyclonedds
     - role: docker
     - role: vcstool
+    - role: ros2
+    - role: calibration_tools
     - role: tier4_hdr_camera_driver
       when: prompt_install_camera_driver == 'y'
-    - role: ros2

--- a/autoware.repos
+++ b/autoware.repos
@@ -23,7 +23,7 @@ repositories:
   calibration_tools:
     type: git
     url: https://github.com/tier4/CalibrationTools.git
-    version: galactic
+    version: tier4/universe
   # package dependencies
   autoware_common_msgs:
     type: git


### PR DESCRIPTION
## Related Links

https://github.com/tier4/perception_ecu_launch/pull/4

## Description

I created ansible file to install dependencies to use `intrinsic_camera_calibrator`.

## Review Procedure

Run setup shell script and build the ROS workspace.

```sh
./setup-dev-env.sh

vcs import src < autoware.repos
vcs pull src

colcon build --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=$(which python3.6) \
  --packages-up-to edge_auto_jetson_launch
```

Execute `intrinsic_camera_calibrator`.

```sh
ros2 launch edge_auto_jetson_launch intrinsic_camera_calibrator.launch.xml 
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
