### PR TITLE
feat: update version of autoware.universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Build your ROS workspace.
 
 ```sh
 colcon build --symlink-install \
-  --cmake-args -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=$(which python3.6) \
+  --cmake-args -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=$(which python3.6) -DCMAKE_CUDA_STANDARD=14\
   --packages-up-to edge_auto_jetson_launch
 ```
 

--- a/autoware.repos
+++ b/autoware.repos
@@ -19,7 +19,7 @@ repositories:
   autoware.universe:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe.git
-    version: galactic
+    version: main
   calibration_tools:
     type: git
     url: https://github.com/tier4/CalibrationTools.git


### PR DESCRIPTION
## Related Links
- https://github.com/tier4/perception_ecu_launch/pull/5

## Description

To exploit recent updates on autoware.universe, including YOLOX improvement and bytetrack introduction, this PR switches the branch for autoware.universe from `galactic` to `master`

## Review Procedure

Run setup shell script and build the ROS workspace.

```sh
./setup-dev-env.sh

vcs import src < autoware.repos
vcs pull src

colcon build --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=$(which python3.6) -DCMAKE_CUDA_STANDARD=14\
  --packages-up-to edge_auto_jetson_launch
```

## Remarks

<!-- Write remarks as you like if you need them. -->
A compile option for `colcon build` is added (i.e., `-DCMAKE_CUDA_STANDARD=14` ) to build the latest autoware.universe on Jetson

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
