### PR TITLE
fix(ansible/setup.yaml): correct handling of prompt result

### DIFF
--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -29,8 +29,8 @@
       when: prompt_install_camera_driver == 'y'
     - role: ros2
     - role: ptp4l_client
-      when: prompt_configure_network
+      when: prompt_configure_network == 'y'
     - role: enlarge_txqueue
-      when: prompt_configure_network
+      when: prompt_configure_network == 'y'
     - role: netplan
-      when: prompt_configure_network
+      when: prompt_configure_network == 'y'


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Currently, I found that the prompt result regarding network configuration is not handled correctly. this PR fixes the handling.

## Related link
- https://github.com/tier4/edge-auto/pull/8

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
