### PR TITLE
feat(andible): add conditions to skip building libraries if working directories exist

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -106,8 +106,7 @@
       become: true
   vars:
     block_name: Boost
-  when:
-    not boost_build_dir_exist.stat.exists
+  when: not boost_build_dir_exist.stat.exists
 
 - name: Check PCL build directory existence
   ansible.builtin.stat:
@@ -140,8 +139,7 @@
       become: true
   vars:
     block_name: PCL
-  when:
-    not pcl_build_dir_exist.stat.exists
+  when: not pcl_build_dir_exist.stat.exists
 
 - name: Check fmt build directory existence
   ansible.builtin.stat:
@@ -172,9 +170,7 @@
       become: true
   vars:
     block_name: fmt
-  when:
-    not fmt_build_dir_exist.stat.exists
-
+  when: not fmt_build_dir_exist.stat.exists
 
 - name: Check Range-v3 build directory existence
   ansible.builtin.stat:
@@ -206,8 +202,7 @@
       become: true
   vars:
     block_name: Range-v3
-  when:
-    not range_v3_build_dir_exist.stat.exists
+  when: not range_v3_build_dir_exist.stat.exists
 
 - name: Check OpenCV build directory existence
   ansible.builtin.stat:
@@ -233,8 +228,7 @@
       become: true
   vars:
     block_name: OpenCV
-  when:
-    not opencv_build_dir_exist.stat.exists
+  when: not opencv_build_dir_exist.stat.exists
 
 - name: Check YAML build directory existence
   ansible.builtin.stat:
@@ -265,8 +259,7 @@
       become: true
   vars:
     block_name: YAML
-  when:
-    not yaml_cpp_build_dir_exist.stat.exists
+  when: not yaml_cpp_build_dir_exist.stat.exists
 
 - name: Upgrade CMake
   block:
@@ -433,8 +426,7 @@
       become: true
   vars:
     block_name: Build ROS
-  when:
-    not ros_build_dir_exist.stat.exists
+  when: not ros_build_dir_exist.stat.exists
 
 - name: Downgrade GCC as version 11 is too high for old CUDA version that is used in L4T
   block:
@@ -465,5 +457,4 @@
     marker: "# {mark} ros2"
     block: |
       source {{ ros_base_dir }}/install/setup.bash
-  when:
-    not ros_build_dir_exist.stat.exists
+  when: not ros_build_dir_exist.stat.exists

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -87,6 +87,11 @@
         path: "{{ source_build_dir }}"
         state: directory
 
+- name: Check Boost build directory existence
+  ansible.builtin.stat:
+    path: "{{ source_build_dir }}/boost_1_74_0"
+  register: boost_build_dir_exist
+
 - name: Build and install Boost
   block:
     - name: "{{ block_name }}: Download and extract source"
@@ -101,6 +106,13 @@
       become: true
   vars:
     block_name: Boost
+  when:
+    not boost_build_dir_exist.stat.exists
+
+- name: Check PCL build directory existence
+  ansible.builtin.stat:
+    path: "{{ source_build_dir }}/pcl"
+  register: pcl_build_dir_exist
 
 - name: Build and install PCL
   block:
@@ -128,6 +140,13 @@
       become: true
   vars:
     block_name: PCL
+  when:
+    not pcl_build_dir_exist.stat.exists
+
+- name: Check fmt build directory existence
+  ansible.builtin.stat:
+    path: "{{ source_build_dir }}/fmt-8.1.1"
+  register: fmt_build_dir_exist
 
 - name: Build and install fmt
   block:
@@ -153,6 +172,14 @@
       become: true
   vars:
     block_name: fmt
+  when:
+    not fmt_build_dir_exist.stat.exists
+
+
+- name: Check Range-v3 build directory existence
+  ansible.builtin.stat:
+    path: "{{ source_build_dir }}/range-v3"
+  register: range_v3_build_dir_exist
 
 - name: Build and install Range-v3
   block:
@@ -179,6 +206,13 @@
       become: true
   vars:
     block_name: Range-v3
+  when:
+    not range_v3_build_dir_exist.stat.exists
+
+- name: Check OpenCV build directory existence
+  ansible.builtin.stat:
+    path: "{{ source_build_dir }}/jetson-containers"
+  register: opencv_build_dir_exist
 
 - name: Build and install OpenCV
   block:
@@ -199,6 +233,13 @@
       become: true
   vars:
     block_name: OpenCV
+  when:
+    not opencv_build_dir_exist.stat.exists
+
+- name: Check YAML build directory existence
+  ansible.builtin.stat:
+    path: "{{ source_build_dir }}/yaml-cpp"
+  register: yaml_cpp_build_dir_exist
 
 - name: Build and install YAML
   block:
@@ -224,6 +265,8 @@
       become: true
   vars:
     block_name: YAML
+  when:
+    not yaml_cpp_build_dir_exist.stat.exists
 
 - name: Upgrade CMake
   block:
@@ -280,6 +323,11 @@
   become: true
   vars:
     block_name: update GCC
+
+- name: Check ROS build directory existence
+  ansible.builtin.stat:
+    path: /opt/ros/{{ ros_distro }}
+  register: ros_build_dir_exist
 
 - name: Build ROS
   block:
@@ -385,6 +433,8 @@
       become: true
   vars:
     block_name: Build ROS
+  when:
+    not ros_build_dir_exist.stat.exists
 
 - name: Downgrade GCC as version 11 is too high for old CUDA version that is used in L4T
   block:
@@ -415,3 +465,5 @@
     marker: "# {mark} ros2"
     block: |
       source {{ ros_base_dir }}/install/setup.bash
+  when:
+    not ros_build_dir_exist.stat.exists


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR adds a minor change to skip building dependent libraries if a working directory for each library already exists

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
