### PR TITLE
fix:(ansible) update model download logic

### DIFF
--- a/ansible/roles/download_models/defaults/main.yaml
+++ b/ansible/roles/download_models/defaults/main.yaml
@@ -1,0 +1,1 @@
+data_dir: /opt/autoware/data

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -1,9 +1,11 @@
 - name: Create data directory
+  become: true
   ansible.builtin.file:
     path: "{{ data_dir }}"
     state: directory
 
 - name: Create tensorrt_yolox directory inside {{ data_dir }}
+  become: true
   ansible.builtin.file:
     path: "{{ data_dir }}/tensorrt_yolox"
     mode: "755"

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -1,0 +1,42 @@
+- name: Create data directory
+  ansible.builtin.file:
+    path: "{{ data_dir }}"
+    state: directory
+
+- name: Create tensorrt_yolox directory inside {{ data_dir }}
+  ansible.builtin.file:
+    path: "{{ data_dir }}/tensorrt_yolox"
+    mode: "755"
+    state: directory
+
+- name: Download tensorrt_yolox/yolox-tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-tiny.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-tiny.onnx"
+    mode: "644"
+    checksum: sha256:471a665f4243e654dff62578394e508db22ee29fe65d9e389dfc3b0f2dee1255
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.onnx"
+    mode: "644"
+    checksum: md5:bf3b0155351f90fcdca2626acbfd3bcf
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: md5:c6e6f1999d5724a017516a956096701f
+
+- name: Download tensorrt_yolox/label.txt
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/label.txt
+    dest: "{{ data_dir }}/tensorrt_yolox/label.txt"
+    mode: "644"
+    checksum: sha256:3540a365bfd6d8afb1b5d8df4ec47f82cb984760d3270c9b41dbbb3422d09a0c

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -18,6 +18,10 @@
       prompt: |-
         [Warning] Do you want to configure the network? This configuration may overwrite the IP address of the specific network interface [y/N]
       private: false
+    - name: prompt_download_models
+      prompt: |-
+        [Warning] Do you want to download onnx models? [y/N]
+      private: false
   roles:
     - role: autoware
     - role: cuda
@@ -34,3 +38,5 @@
       when: prompt_configure_network == 'y'
     - role: netplan
       when: prompt_configure_network == 'y'
+    - role: download_models
+      when: prompt_download_models == 'y'


### PR DESCRIPTION
## Description

This PR fixes edge-auto to align with Autoware Universe's new model download logic.

## Related Links
- https://github.com/autowarefoundation/autoware.universe/issues/3137
- https://github.com/tier4/edge-auto/pull/17
- https://github.com/tier4/edge_auto_launch/pull/15

## Tests performed

Centerpoint and YOLOX from edge-auto and edge-auto-jetson respectively, were launched, and I confirmed that they were outputting predictions at the correct frequency (~10 Hz).

## Effects on system behavior

Previously, edge-auto's model downloading was broken by an update to Autoware Universe, such that YOLOX and Centerpoint would not be able to launch. This PR updates edge-auto to correctly download models under Autoware Universe's new scheme.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
