### PR TITLE
feat: unify edge auto perception

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -31,10 +31,6 @@ repositories:
     type: git
     url: https://github.com/tier4/edge_auto_individual_params.git
     version: main
-  calibration_tools:
-    type: git
-    url: https://github.com/tier4/CalibrationTools.git
-    version: tier4/universe
   nebula:
     type: git
     url: https://github.com/tier4/nebula.git
@@ -43,22 +39,6 @@ repositories:
     type: git
     url: https://github.com/MapIV/transport_drivers.git
     version: boost
-  lidartag:
-    type: git
-    url: https://github.com/tier4/LiDARTag.git
-    version: humble
-  lidartag_msgs:
-    type: git
-    url: https://github.com/tier4/LiDARTag_msgs.git
-    version: tier4/universe
-  apriltag_msgs:
-    type: git
-    url: https://github.com/christianrauch/apriltag_msgs.git
-    version: 2.0.0
-  apriltag_ros:
-    type: git
-    url: https://github.com/christianrauch/apriltag_ros.git
-    version: e814e9e5d5f1bfb60a4aa685d30977c632bbc540
   ros2_numpy:
     type: git
     url: https://github.com/Box-Robotics/ros2_numpy.git
@@ -92,36 +72,7 @@ repositories:
     type: git
     url: https://github.com/tier4/tensorrt_cmake_module.git
     version: main
-  perception_pcl:
-    type: git
-    url: https://github.com/ros-perception/perception_pcl.git
-    version: ros2
-  pcl_msgs:
-    type: git
-    url: https://github.com/ros-perception/pcl_msgs.git
-    version: ros2
-  logging_demo:
-    type: git
-    url: https://github.com/ros2/demos.git
-    version: humble
-  # from nebula
-  udp_msgs:
-    type: git
-    url: https://github.com/flynneva/udp_msgs.git
-    version: main
-  angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: humble-devel
-  diagnostics:
-    type: git
-    url: https://github.com/ros/diagnostics.git
-    version: ros2
   # other build dependencies
-  tf_transformations:
-    type: git
-    url: https://github.com/DLu/tf_transformations.git
-    version: main
   point_cloud_msg_wrapper:
     type: git
     url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
@@ -130,63 +81,3 @@ repositories:
     type: git
     url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
     version: master
-  usb_cam:
-    type: git
-    url: https://github.com/ros-drivers/usb_cam.git
-    version: ros2
-  apriltag:
-    type: git
-    url: https://github.com/AprilRobotics/apriltag.git
-    version: master
-  mrt_cmake_modules:
-    type: git
-    url: https://github.com/KIT-MRT/mrt_cmake_modules.git
-    version: master
-  gtest_vendor:
-    type: git
-    url: https://github.com/ament/googletest.git
-    version: humble
-  grid_map:
-    type: git
-    url: https://github.com/ANYbotics/grid_map.git
-    version: humble
-  filters:
-    type: git
-    url: https://github.com/ros/filters.git
-    version: ros2
-  nav2_msgs:
-    type: git
-    url: https://github.com/ros-planning/navigation2.git
-    version: humble
-#  rviz2:
-#    type: git
-#    url: https://github.com/ros2/rviz.git
-#    version: humble
-#  resource_retriever:
-#    type: git
-#    url: https://github.com/ros/resource_retriever.git
-#    version: humble
-  tf2-eigen:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: humble
-#  eigenpy:
-#    type: git
-#    url: https://github.com/stack-of-tasks/eigenpy.git
-#    version: devel
-  quaternion_operation:
-    type: git
-    url: https://github.com/OUXT-Polaris/quaternion_operation.git
-    version: ros2
-  ouxt_lint_common:
-    type: git
-    url: https://github.com/OUXT-Polaris/ouxt_common.git
-    version: master
-  ament_cmake_clang_format:
-    type: git
-    url: https://github.com/ament/ament_lint.git
-    version: humble
-  tensorrt_cmake_module:
-    type: git
-    url: https://github.com/tier4/tensorrt_cmake_module.git
-    version: main

--- a/autoware.repos
+++ b/autoware.repos
@@ -25,7 +25,7 @@ repositories:
     version: tier4/universe
   launcher:
     type: git
-    url: https://github.com/tier4/edge_auto_launch.git
+    url: https://github.com/tier4/edge_auto_jetson_launch.git
     version: main
   individual_params:
     type: git
@@ -47,11 +47,7 @@ repositories:
     type: git
     url: https://github.com/tier4/image_pipeline.git
     version: 47964112293eb19f9f57254b2e6b68706954cc63
-  # edge-auto-jetson
-  camera_perception_launcher:
-    type: git
-    url: https://github.com/tier4/edge_auto_jetson_launch.git
-    version: main
+  # edge-auto-jetson deps
   sensor_trigger:
     type: git
     url: https://github.com/tier4/sensor_trigger.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,12 +1,76 @@
 repositories:
-  # perception stack
+  autoware.universe:
+    type: git
+    url: https://github.com/autowarefoundation/autoware.universe.git
+    version: main
+  autoware_common:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_common.git
+    version: main
+  autoware_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: main
+  autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: main
+  autoware_auto_msgs:
+    type: git
+    url: https://github.com/tier4/autoware_auto_msgs.git
+    version: tier4/main
+  tier4_autoware_msgs:
+    type: git
+    url: https://github.com/tier4/tier4_autoware_msgs.git
+    version: tier4/universe
   launcher:
     type: git
-    url: https://github.com/tier4/edge_auto_jetson_launch.git
+    url: https://github.com/tier4/edge_auto_launch.git
     version: main
   individual_params:
     type: git
     url: https://github.com/tier4/edge_auto_individual_params.git
+    version: main
+  calibration_tools:
+    type: git
+    url: https://github.com/tier4/CalibrationTools.git
+    version: tier4/universe
+  nebula:
+    type: git
+    url: https://github.com/tier4/nebula.git
+    version: main
+  transport_drivers:
+    type: git
+    url: https://github.com/MapIV/transport_drivers.git
+    version: boost
+  lidartag:
+    type: git
+    url: https://github.com/tier4/LiDARTag.git
+    version: humble
+  lidartag_msgs:
+    type: git
+    url: https://github.com/tier4/LiDARTag_msgs.git
+    version: tier4/universe
+  apriltag_msgs:
+    type: git
+    url: https://github.com/christianrauch/apriltag_msgs.git
+    version: 2.0.0
+  apriltag_ros:
+    type: git
+    url: https://github.com/christianrauch/apriltag_ros.git
+    version: e814e9e5d5f1bfb60a4aa685d30977c632bbc540
+  ros2_numpy:
+    type: git
+    url: https://github.com/Box-Robotics/ros2_numpy.git
+    version: humble
+  image_pipeline:
+    type: git
+    url: https://github.com/tier4/image_pipeline.git
+    version: 47964112293eb19f9f57254b2e6b68706954cc63
+  # edge-auto-jetson
+  camera_perception_launcher:
+    type: git
+    url: https://github.com/tier4/edge_auto_jetson_launch.git
     version: main
   sensor_trigger:
     type: git
@@ -16,40 +80,10 @@ repositories:
     type: git
     url: https://github.com/tier4/ros2_v4l2_camera.git
     version: galactic
-  autoware.universe:
-    type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
-    version: main
-  calibration_tools:
-    type: git
-    url: https://github.com/tier4/CalibrationTools.git
-    version: tier4/universe
-  # package dependencies
-  autoware_common_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: main
-  autoware_common:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
-    version: main
-  tier4_autoware_msgs:
-    type: git
-    url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: tier4/universe
-  autoware_auto_msgs:
-    type: git
-    url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
-  image_pipeline:
-    type: git
-    url: https://github.com/tier4/image_pipeline.git
-    version: tier4/main
   image_transport_plugins:
     type: git
     url: https://github.com/ros-perception/image_transport_plugins.git
     version: humble
-  # build dependencies
   cudnn_cmake_module:
     type: git
     url: https://github.com/tier4/cudnn_cmake_module.git
@@ -70,3 +104,89 @@ repositories:
     type: git
     url: https://github.com/ros2/demos.git
     version: humble
+  # from nebula
+  udp_msgs:
+    type: git
+    url: https://github.com/flynneva/udp_msgs.git
+    version: main
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: humble-devel
+  diagnostics:
+    type: git
+    url: https://github.com/ros/diagnostics.git
+    version: ros2
+  # other build dependencies
+  tf_transformations:
+    type: git
+    url: https://github.com/DLu/tf_transformations.git
+    version: main
+  point_cloud_msg_wrapper:
+    type: git
+    url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+    version: rolling
+  lanelet2_validation:
+    type: git
+    url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+    version: master
+  usb_cam:
+    type: git
+    url: https://github.com/ros-drivers/usb_cam.git
+    version: ros2
+  apriltag:
+    type: git
+    url: https://github.com/AprilRobotics/apriltag.git
+    version: master
+  mrt_cmake_modules:
+    type: git
+    url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+    version: master
+  gtest_vendor:
+    type: git
+    url: https://github.com/ament/googletest.git
+    version: humble
+  grid_map:
+    type: git
+    url: https://github.com/ANYbotics/grid_map.git
+    version: humble
+  filters:
+    type: git
+    url: https://github.com/ros/filters.git
+    version: ros2
+  nav2_msgs:
+    type: git
+    url: https://github.com/ros-planning/navigation2.git
+    version: humble
+#  rviz2:
+#    type: git
+#    url: https://github.com/ros2/rviz.git
+#    version: humble
+#  resource_retriever:
+#    type: git
+#    url: https://github.com/ros/resource_retriever.git
+#    version: humble
+  tf2-eigen:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: humble
+#  eigenpy:
+#    type: git
+#    url: https://github.com/stack-of-tasks/eigenpy.git
+#    version: devel
+  quaternion_operation:
+    type: git
+    url: https://github.com/OUXT-Polaris/quaternion_operation.git
+    version: ros2
+  ouxt_lint_common:
+    type: git
+    url: https://github.com/OUXT-Polaris/ouxt_common.git
+    version: master
+  ament_cmake_clang_format:
+    type: git
+    url: https://github.com/ament/ament_lint.git
+    version: humble
+  tensorrt_cmake_module:
+    type: git
+    url: https://github.com/tier4/tensorrt_cmake_module.git
+    version: main

--- a/autoware.repos
+++ b/autoware.repos
@@ -48,7 +48,7 @@ repositories:
   image_transport_plugins:
     type: git
     url: https://github.com/ros-perception/image_transport_plugins.git
-    version: foxy-devel
+    version: humble
   # build dependencies
   cudnn_cmake_module:
     type: git
@@ -58,3 +58,15 @@ repositories:
     type: git
     url: https://github.com/tier4/tensorrt_cmake_module.git
     version: main
+  perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl.git
+    version: ros2
+  pcl_msgs:
+    type: git
+    url: https://github.com/ros-perception/pcl_msgs.git
+    version: ros2
+  logging_demo:
+    type: git
+    url: https://github.com/ros2/demos.git
+    version: humble

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 colcon build \
     --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
     -DPython3_EXECUTABLE=$(which python3.8) -DCMAKE_CUDA_STANDARD=14 \
-    --packages-up-to edge_auto_jetson_launch
+    --packages-up-to edge_auto_launch

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 colcon build \
     --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
-    -DPython3_EXECUTABLE=$(which python3.6) -DCMAKE_CUDA_STANDARD=14 \
+    -DPython3_EXECUTABLE=$(which python3.8) -DCMAKE_CUDA_STANDARD=14 \
     --packages-up-to edge_auto_jetson_launch

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 colcon build \
     --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
     -DPython3_EXECUTABLE=$(which python3.8) -DCMAKE_CUDA_STANDARD=14 \
-    --packages-up-to edge_auto_launch
+    --packages-up-to edge_auto_jetson_launch


### PR DESCRIPTION
## Description

This PR adds allows the execution of both 2D and 3D edge-auto perception on CTI Anvil.

## Related links

- https://github.com/tier4/edge_auto_jetson_launch/pull/11

## Tests performed

This repository was built and run, both with rosbag (AT128 and X32 samples) and C2 camera + AT128 setup. Visually examining results confirms that all nodes were running correctly.

## Notes for reviewers

LiDAR perception cannot be run until the appropriate modifications are made to edge_auto_jetson_launch (see _related links_)

## Effects on system behavior

This PR preserves previous edge ECU capabilities while adding the ability to run 3D perception on an edge ECU (CTI Anvil)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
