### PR TITLE
fix(ansible): CTI Anvil update model download logic

### DIFF
--- a/ansible/roles/calibration_tools/tasks/main.yaml
+++ b/ansible/roles/calibration_tools/tasks/main.yaml
@@ -1,6 +1,6 @@
 - name: Fix python interpreter version to 3
   set_fact:
-    ansible_python_interpreter: /usr/bin/python3.6
+    ansible_python_interpreter: /usr/bin/python3.8
 
 - name: Upgrade pip
   pip:

--- a/ansible/roles/download_models/defaults/main.yaml
+++ b/ansible/roles/download_models/defaults/main.yaml
@@ -1,0 +1,1 @@
+data_dir: /opt/autoware/data

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -1,0 +1,83 @@
+- name: Create data directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ data_dir }}"
+    state: directory
+
+- name: Create tensorrt_yolox directory inside {{ data_dir }}
+  become: true
+  ansible.builtin.file:
+    path: "{{ data_dir }}/tensorrt_yolox"
+    mode: "755"
+    state: directory
+
+- name: Download tensorrt_yolox/yolox-tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-tiny.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-tiny.onnx"
+    mode: "644"
+    checksum: sha256:471a665f4243e654dff62578394e508db22ee29fe65d9e389dfc3b0f2dee1255
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.onnx"
+    mode: "644"
+    checksum: md5:bf3b0155351f90fcdca2626acbfd3bcf
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: md5:c6e6f1999d5724a017516a956096701f
+
+- name: Download tensorrt_yolox/label.txt
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/label.txt
+    dest: "{{ data_dir }}/tensorrt_yolox/label.txt"
+    mode: "644"
+    checksum: sha256:3540a365bfd6d8afb1b5d8df4ec47f82cb984760d3270c9b41dbbb3422d09a0c
+
+- name: Create lidar_centerpoint directory inside {{ data_dir }}
+  become: true
+  ansible.builtin.file:
+    path: "{{ data_dir }}/lidar_centerpoint"
+    mode: "755"
+    state: directory
+
+- name: Download lidar_centerpoint/pts_voxel_encoder_centerpoint.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_voxel_encoder_centerpoint.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_voxel_encoder_centerpoint.onnx"
+    mode: "644"
+    checksum: sha256:dc1a876580d86ee7a341d543f8ade2ede7f43bd032dc5b44155b1f0175405764
+
+- name: Download lidar_centerpoint/pts_backbone_neck_head_centerpoint.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_backbone_neck_head_centerpoint.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_backbone_neck_head_centerpoint.onnx"
+    mode: "644"
+    checksum: sha256:3fe7e128955646740c41a25be0c8f141d5a94594fe79d7405fe2a859e391542e
+
+- name: Download lidar_centerpoint/pts_voxel_encoder_centerpoint_tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_voxel_encoder_centerpoint_tiny.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_voxel_encoder_centerpoint_tiny.onnx"
+    mode: "644"
+    checksum: sha256:2c53465715c1fd2e9dc5727ef3fca74f4cdf0538f74286b0946e219d0ca5693b
+
+- name: Download lidar_centerpoint/pts_backbone_neck_head_centerpoint_tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_backbone_neck_head_centerpoint_tiny.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_backbone_neck_head_centerpoint_tiny.onnx"
+    mode: "644"
+    checksum: md5:e4658325b70222f7c3637fe00e586b82

--- a/ansible/roles/ptp4l_client/defaults/main.yaml
+++ b/ansible/roles/ptp4l_client/defaults/main.yaml
@@ -1,1 +1,1 @@
-ptp4l_client_interface: mgbe0
+ptp4l_client_interface: eqos0

--- a/ansible/roles/ptp4l_client/defaults/main.yaml
+++ b/ansible/roles/ptp4l_client/defaults/main.yaml
@@ -1,1 +1,1 @@
-ptp4l_client_interface: eth1
+ptp4l_client_interface: mgbe0

--- a/ansible/roles/ptp4l_host/defaults/main.yaml
+++ b/ansible/roles/ptp4l_host/defaults/main.yaml
@@ -1,0 +1,2 @@
+ptp4l_host_interface:
+  - mgbe0

--- a/ansible/roles/ptp4l_host/defaults/main.yaml
+++ b/ansible/roles/ptp4l_host/defaults/main.yaml
@@ -1,2 +1,2 @@
 ptp4l_host_interface:
-  - mgbe0
+  - eth0

--- a/ansible/roles/ptp4l_host/files/ptp4l@.service
+++ b/ansible/roles/ptp4l_host/files/ptp4l@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Precision Time Protocol (PTP) service
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/ptp4l -i %i -m -S -A
+ExecStop=/usr/bin/pkill -f ptp4l
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target network-online.target

--- a/ansible/roles/ptp4l_host/tasks/main.yaml
+++ b/ansible/roles/ptp4l_host/tasks/main.yaml
@@ -1,15 +1,15 @@
-# - name: Install ptp4l
-#   ansible.builtin.apt:
-#     name:
-#       - linuxptp
-#     update_cache: true
-#   become: true
+- name: Install ptp4l
+  ansible.builtin.apt:
+    name:
+      - linuxptp
+    update_cache: true
+  become: true
 
-# - name: Copy service template file
-#   ansible.builtin.copy:
-#     src: ptp4l@.service
-#     dest: /etc/systemd/system/
-#   become: true
+- name: Copy service template file
+  ansible.builtin.copy:
+    src: ptp4l@.service
+    dest: /etc/systemd/system/
+  become: true
 
 - name: Install ptp4l client service file
   ansible.builtin.systemd:

--- a/ansible/roles/ptp4l_host/tasks/main.yaml
+++ b/ansible/roles/ptp4l_host/tasks/main.yaml
@@ -1,0 +1,21 @@
+- name: Install ptp4l
+  ansible.builtin.apt:
+    name:
+      - linuxptp
+    update_cache: true
+  become: true
+
+- name: Copy service template file
+  ansible.builtin.copy:
+    src: ptp4l@.service
+    dest: /etc/systemd/system/
+  become: true
+
+- name: Install ptp4l client service file
+  ansible.builtin.systemd:
+    name: ptp4l@{{ item }}.service
+    daemon_reload: true
+    enabled: true
+    masked: false
+  become: true
+  with_items: "{{ ptp4l_host_interface }}"

--- a/ansible/roles/ptp4l_host/tasks/main.yaml
+++ b/ansible/roles/ptp4l_host/tasks/main.yaml
@@ -1,15 +1,15 @@
-- name: Install ptp4l
-  ansible.builtin.apt:
-    name:
-      - linuxptp
-    update_cache: true
-  become: true
+# - name: Install ptp4l
+#   ansible.builtin.apt:
+#     name:
+#       - linuxptp
+#     update_cache: true
+#   become: true
 
-- name: Copy service template file
-  ansible.builtin.copy:
-    src: ptp4l@.service
-    dest: /etc/systemd/system/
-  become: true
+# - name: Copy service template file
+#   ansible.builtin.copy:
+#     src: ptp4l@.service
+#     dest: /etc/systemd/system/
+#   become: true
 
 - name: Install ptp4l client service file
   ansible.builtin.systemd:

--- a/ansible/roles/ros2/defaults/main.yaml
+++ b/ansible/roles/ros2/defaults/main.yaml
@@ -1,3 +1,3 @@
 ros_root_dir: /opt/ros/humble
 ros_pkg: ros_base
-skip_keys: "libopencv-dev libopencv-contrib-dev libopencv-imgproc-dev python-opencv python3-opencv"
+skip_keys: "libopencv-dev python3-catkin-pkg-modules"

--- a/ansible/roles/ros2/defaults/main.yaml
+++ b/ansible/roles/ros2/defaults/main.yaml
@@ -1,3 +1,2 @@
 ros_root_dir: /opt/ros/humble
 ros_pkg: ros_base
-skip_keys: "libopencv-dev python3-catkin-pkg-modules"

--- a/ansible/roles/ros2/defaults/main.yaml
+++ b/ansible/roles/ros2/defaults/main.yaml
@@ -1,0 +1,3 @@
+ros_root_dir: /opt/ros/humble
+ros_pkg: ros_base
+skip_keys: "libopencv-dev libopencv-contrib-dev libopencv-imgproc-dev python-opencv python3-opencv"

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -31,15 +31,15 @@
       set_fact:
         ros2_build_script: "{{ jetson_script_dir }}/ros2_build.sh"
     - name: Download OpenCV deps script
-      ansible.builtin.get-uri:
+      ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/opencv_install_deps.sh
         dest: "{{ opencv_install_deps_script }}"
     - name: Download OpenCV install script
-      ansible.builtin.get-uri:
+      ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/opencv_install.sh
         dest: "{{ opencv_install_script }}"
     - name: Download ROS2 Humble install script
-      ansible.builtin.get-uri:
+      ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/ros2_build.sh
         dest: "{{ ros2_build_script }}"
 

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -1,460 +1,114 @@
-- name: Fix python interpreter version to 3
-  set_fact:
-    ansible_python_interpreter: /usr/bin/python3.6
-
-- name: Setup dependencies
+- name: Confirm locale
   block:
-    - name: Apt install
-      ansible.builtin.apt:
-        name:
-          - curl
-          - wget
-          - gnupg
-          - gnupg2
-          - lsb-release
-          - ca-certificates
-          - software-properties-common
-          - apt-transport-https
-        install_recommends: false
-        update_cache: true
-    - name: Add ROS2 source list
-      shell: echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-    - name: Download gpg key
-      ansible.builtin.uri:
-        url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
-        dest: /usr/share/keyrings/ros-archive-keyring.gpg
-        follow_redirects: all
-    - name: Apt install
-      ansible.builtin.apt:
-        name:
-          - nvidia-jetpack
-          - build-essential
-          - cmake
-          - git
-          - libbullet-dev
-          - libpython3-dev
-          - python3-wheel
-          - python3-colcon-common-extensions
-          - python3-flake8
-          - python3-pip
-          - python3-numpy
-          - python3-pytest-cov
-          - python3-rosdep
-          - python3-setuptools
-          - python3-vcstool
-          - python3-rosinstall-generator
-          - libasio-dev
-          - libtinyxml2-dev
-          - libcunit1-dev
-          - libflann-dev
-        install_recommends: false
-        update_cache: true
+    - name: Generate locale files
+      ansible.builtin.command:
+        cmd: locale-gen en_US en_US.UTF-8
+    - name: Update locale settings
+      ansible.builtin.command:
+        cmd: update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
   become: true
 
-- name: add CUDA into PATH
+- name: Fix python interpreter version to 3
   set_fact:
-    environment:
-      PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
+    ansible_python_interpreter: /usr/bin/python3.8
 
-- name: Python parts
-  ansible.builtin.pip:
-    name:
-      - wheel
-      - argcomplete
-      - flake8-blind-except
-      - flake8-builtins
-      - flake8-class-newline
-      - flake8-comprehensions
-      - flake8-deprecated
-      - flake8-docstrings
-      - flake8-import-order
-      - flake8-quotes
-      - pytest-repeat
-      - pytest-rerunfailures
-      - pytest
-      - pybind11-global
-      - importlib_resources
-    extra_args: -U
-  become: true # need to sudo privilege to install packages globally
-
-- name: Prepare for dependencies' source build
+- name: Prepare Jetson scripts
   block:
     - name: Define directory name
       set_fact:
-        source_build_dir: "{{ ansible_env.HOME }}/source_builds"
+        jetson_script_dir: "{{ ansible_env.HOME }}/jetson_scripts"
     - name: Create directory
       ansible.builtin.file:
-        path: "{{ source_build_dir }}"
+        path: "{{ jetson_script_dir }}"
         state: directory
+    - name: Define file name
+      set_fact:
+        opencv_install_deps_script: "{{ jetson_script_dir }}/opencv_install_deps.sh"
+    - name: Define file name
+      set_fact:
+        opencv_install_script: "{{ jetson_script_dir }}/opencv_install.sh"
+    - name: Define file name
+      set_fact:
+        ros2_build_script: "{{ jetson_script_dir }}/ros2_build.sh"
+    - name: Download OpenCV deps script
+      ansible.builtin.get-uri:
+        url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/opencv_install_deps.sh
+        dest: "{{ opencv_install_deps_script }}"
+    - name: Download OpenCV install script
+      ansible.builtin.get-uri:
+        url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/opencv_install.sh
+        dest: "{{ opencv_install_script }}"
+    - name: Download ROS2 Humble install script
+      ansible.builtin.get-uri:
+        url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/ros2_build.sh
+        dest: "{{ ros2_build_script }}"
 
-- name: Check Boost build directory existence
-  ansible.builtin.stat:
-    path: "{{ source_build_dir }}/boost_1_74_0"
-  register: boost_build_dir_exist
-
-- name: Build and install Boost
+- name: Install dependencies
   block:
-    - name: "{{ block_name }}: Download and extract source"
-      ansible.builtin.unarchive:
-        src: https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz
-        dest: "{{ source_build_dir }}"
-        remote_src: yes
-    - name: "{{ block_name }}: Build boost"
-      shell: ./bootstrap.sh --prefix=/usr/local --with-python=python3 && ./b2 install -j7
-      args:
-        chdir: "{{ source_build_dir }}/boost_1_74_0"
-      become: true
-  vars:
-    block_name: Boost
-  when: not boost_build_dir_exist.stat.exists
+    - name: Install jetpack
+      ansible.builtin.apt:
+        name:
+          - nvidia-jetpack
+        install_recommends: false
+        update_cache: true
+    - name: Install OpenCV deps
+      ansible.builtin.command:
+        cmd: "{{ opencv_install_deps_script }}"
+    - name: Install PCL deps
+      ansible.builtin.apt:
+        name:
+          - libflann-dev
+          - libboost-filesystem-dev
+          - libboost-date-time-dev
+          - libboost-iostreams-dev
+        install_recommends: false
+        update_cache: true
+  become: true
 
-- name: Check PCL build directory existence
-  ansible.builtin.stat:
-    path: "{{ source_build_dir }}/pcl"
-  register: pcl_build_dir_exist
-
-- name: Build and install PCL
+- name: Install PCL
   block:
-    - name: "{{ block_name }}: Download and extract source"
-      ansible.builtin.unarchive:
-        src: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
-        dest: "{{ source_build_dir }}"
-        remote_src: yes
-    - set_fact:
-        pcl_build_dir: "{{ source_build_dir }}/pcl/build"
-    - name: "{{ block_name }}: Create build directory"
+    - name: Define directory name
+      set_fact:
+        pcl_directory: "{{ ansible_env.HOME }}/pcl"
+    - name: Create build directory
       ansible.builtin.file:
-        path: "{{ pcl_build_dir }}"
+        path: pcl_directory
+    - name: Download and extract PCL 1.12.1 source
+      ansible.builtin.unarchive:
+        url: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
+        dest: "{{ pcl_directory }}"
+        remote_src: yes
+    - name: Create build directory
+      ansible.builtin.file:
+        path: "{{ pcl_directory }}/pcl/build"
         state: directory
-    - name: "{{ block_name }}: cmake"
-      shell: cmake -DCMAKE_BUILD_TYPE=Release ..
-      args:
-        chdir: "{{ pcl_build_dir }}"
+    - name: Run cmake
+      ansible.builtin.command:
+        cmd: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
+        chdir: "{{ pcl_directory }}/pcl/build"
       environment:
         PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
-    - name: "{{ block_name }}: build"
-      shell: make -j7 install
-      args:
-        chdir: "{{ pcl_build_dir }}"
+    - name: Install PCL
+      ansible.builtin.command:
+        cmd: make -j7 install
+        chdir: "{{ pcl_directory }}/pcl/build"
       become: true
-  vars:
-    block_name: PCL
-  when: not pcl_build_dir_exist.stat.exists
 
-- name: Check fmt build directory existence
-  ansible.builtin.stat:
-    path: "{{ source_build_dir }}/fmt-8.1.1"
-  register: fmt_build_dir_exist
+- name: Install OpenCV
+  ansible.builtin.command:
+    cmd: "{{ opencv_install_script }} {{ opencv_url }} {{ opencv_deb }}"
 
-- name: Build and install fmt
-  block:
-    - name: "{{ block_name }}: Download and extract source"
-      ansible.builtin.unarchive:
-        src: https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz
-        dest: "{{ source_build_dir }}"
-        remote_src: yes
-    - set_fact:
-        fmt_build_dir: "{{ source_build_dir }}/fmt-8.1.1/build"
-    - name: "{{ block_name }}: Create build directory"
-      ansible.builtin.file:
-        path: "{{ fmt_build_dir }}"
-        state: directory
-    - name: "{{ block_name }}: cmake"
-      shell: cmake -DBUILD_SHARED_LIBS=TRUE ..
-      args:
-        chdir: "{{ fmt_build_dir }}"
-    - name: "{{ block_name }}: build"
-      shell: make -j7 install
-      args:
-        chdir: "{{ fmt_build_dir }}"
-      become: true
-  vars:
-    block_name: fmt
-  when: not fmt_build_dir_exist.stat.exists
+- name: Build ROS2 Humble
+  ansible.builtin.command:
+    cmd: "{{ ros2_build_script }}"
+  environment:
+    ROS_DISTRO: "{{ ros_distro }}"
+    ROS_PKG: ros_base
+    ROS_ROOT: "/opt/ros/{{ ros_distro }}"
 
-- name: Check Range-v3 build directory existence
-  ansible.builtin.stat:
-    path: "{{ source_build_dir }}/range-v3"
-  register: range_v3_build_dir_exist
-
-- name: Build and install Range-v3
-  block:
-    - name: "{{ block_name }}: Download source"
-      ansible.builtin.git:
-        repo: https://github.com/ericniebler/range-v3.git
-        dest: "{{ source_build_dir }}/range-v3"
-        depth: 1
-        version: 0.11.0
-    - set_fact:
-        range_v3_build_dir: "{{ source_build_dir }}/range-v3/build"
-    - name: "{{ block_name }}: Create build directory"
-      ansible.builtin.file:
-        path: "{{ range_v3_build_dir }}"
-        state: directory
-    - name: "{{ block_name }}: cmake"
-      shell: cmake -DCMAKE_BUILD_TYPE=Release -DRANGE_V3_TESTS=Off -DRANGE_V3_EXAMPLES=Off ..
-      args:
-        chdir: "{{ range_v3_build_dir }}"
-    - name: "{{ block_name }}: build"
-      shell: make -j7 install
-      args:
-        chdir: "{{ range_v3_build_dir }}"
-      become: true
-  vars:
-    block_name: Range-v3
-  when: not range_v3_build_dir_exist.stat.exists
-
-- name: Check OpenCV build directory existence
-  ansible.builtin.stat:
-    path: "{{ source_build_dir }}/jetson-containers"
-  register: opencv_build_dir_exist
-
-- name: Build and install OpenCV
-  block:
-    - name: "{{ block_name }}: Download install script"
-      ansible.builtin.git:
-        repo: https://github.com/dusty-nv/jetson-containers.git
-        dest: "{{ source_build_dir }}/jetson-containers"
-        version: L4T-R35.1.0
-    - name: "{{ block_name }}: install dependencies"
-      shell: ./opencv_install_deps.sh
-      args:
-        chdir: "{{ source_build_dir }}/jetson-containers/scripts"
-      become: true
-    - name: "{{ block_name }}: execute install script"
-      shell: ./opencv_install.sh https://nvidia.box.com/shared/static/5v89u6g5rb62fpz4lh0rz531ajo2t5ef.gz OpenCV-4.5.0-aarch64.tar.gz
-      args:
-        chdir: "{{ source_build_dir }}/jetson-containers/scripts"
-      become: true
-  vars:
-    block_name: OpenCV
-  when: not opencv_build_dir_exist.stat.exists
-
-- name: Check YAML build directory existence
-  ansible.builtin.stat:
-    path: "{{ source_build_dir }}/yaml-cpp"
-  register: yaml_cpp_build_dir_exist
-
-- name: Build and install YAML
-  block:
-    - name: "{{ block_name }}: Download source"
-      ansible.builtin.git:
-        repo: https://github.com/jbeder/yaml-cpp.git
-        dest: "{{ source_build_dir }}/yaml-cpp"
-        version: yaml-cpp-0.6.0
-    - set_fact:
-        yaml_cpp_build_dir: "{{ source_build_dir }}/yaml-cpp/build"
-    - name: "{{ block_name }}: Create build directory"
-      ansible.builtin.file:
-        path: "{{ yaml_cpp_build_dir }}"
-        state: directory
-    - name: "{{ block_name }}: cmake"
-      shell: cmake -DBUILD_SHARED_LIBS=ON ..
-      args:
-        chdir: "{{ yaml_cpp_build_dir }}"
-    - name: "{{ block_name }}: build"
-      shell: make -j7 install
-      args:
-        chdir: "{{ yaml_cpp_build_dir }}"
-      become: true
-  vars:
-    block_name: YAML
-  when: not yaml_cpp_build_dir_exist.stat.exists
-
-- name: Upgrade CMake
-  block:
-    - name: "{{ block_name }}: update gpg key"
-      shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-    # Follow drirections here: https://apt.kitware.com/
-    - name: "{{ block_name }}: update repository info"
-      ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ {{ ansible_distribution_release }} main"
-        filename: kitware
-    - name: "{{ block_name }}: apt update"
-      ansible.builtin.apt:
-        update_cache: true
-        state: present
-    # - name: "{{ block_name }}: delete gpg key"
-    #   ansible.builtin.file:
-    #     path: /usr/share/keyrings/kitware-archive-keyring.gpg
-    #     state: absent
-    - name: "{{ block_name }}: install kitware-arcyhive-keyring"
-      ansible.builtin.apt:
-        name: kitware-archive-keyring
-    - name: "{{ block_name }}: install newer cmake"
-      ansible.builtin.apt:
-        name: cmake
-        install_recommends: false
-        state: latest
+- name: Install extra edge-auto-jetson dependency
+  ansible.builtin.apt:
+    name: libtheora-dev
+    install_recommends: false
+    update_cache: true
   become: true
-  vars:
-    block_name: Upgrade CMake
-
-- name: update GCC
-  block:
-    - name: "{{ block_name }}: update repository info"
-      ansible.builtin.apt_repository:
-        repo: ppa:ubuntu-toolchain-r/test
-    - name: "{{ block_name }}: install gcc11"
-      ansible.builtin.apt:
-        name:
-          - gcc-11
-          - g++-11
-        install_recommends: false
-        update_cache: true
-    - name: "{{ block_name }}: set gcc11 as default"
-      community.general.alternatives:
-        name: gcc
-        path: /usr/bin/gcc-11
-        link: /usr/bin/gcc
-        state: selected
-        subcommands:
-          - name: g++
-            path: /usr/bin/g++-11
-            link: /usr/bin/g++
-
-  become: true
-  vars:
-    block_name: update GCC
-
-- name: Check ROS build directory existence
-  ansible.builtin.stat:
-    path: /opt/ros/{{ ros_distro }}
-  register: ros_build_dir_exist
-
-- name: Build ROS
-  block:
-    - set_fact:
-        ros_base_dir: "/opt/ros/{{ ros_distro }}"
-    - set_fact:
-        ros_src_dir: "{{ ros_base_dir }}/src"
-    - name: "{{ block_name }}: Create base directory"
-      ansible.builtin.file:
-        path: "{{ ros_base_dir }}"
-        state: directory
-      become: true
-    - name: "{{ block_name }}: Create soruce directory"
-      ansible.builtin.file:
-        path: "{{ ros_base_dir }}/src"
-        state: directory
-      become: true
-    - name: "{{ block_name }}: generate repository list using rosinstall_generator"
-      shell: "rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall"
-    - name: "{{ block_name }}: copy repository list to target ddirectory"
-      ansible.builtin.copy:
-        src: "/tmp/ros2.{{ ros_distro }}.ros_base.rosinstall"
-        dest: "{{ ros_base_dir }}/ros2.{{ ros_distro }}.ros_base.rosinstall"
-      become: true
-    - name: "{{ block_name }}: clone all repositories via vcs"
-      shell: "vcs import src < ros2.{{ ros_distro }}.ros_base.rosinstall"
-      args:
-        chdir: "{{ ros_base_dir }}"
-      become: true
-    - name: "{{ block_name }}: remove ament_cmake for update"
-      ansible.builtin.file:
-        path: "{{ ros_src_dir }}/ament_cmake"
-        state: absent
-      become: true
-    - name: "{{ block_name }}: clone ament_cmake from git"
-      ansible.builtin.git:
-        repo: https://github.com/ament/ament_cmake
-        dest: "{{ ros_src_dir }}/ament_cmake"
-        version: humble
-      become: true
-    - name: "{{ block_name }}: clone diagnostics from git"
-      ansible.builtin.git:
-        repo: https://github.com/ros/diagnostics
-        dest: "{{ ros_src_dir }}/diagnostics"
-        version: ros2
-      become: true
-    - name: "{{ block_name }}: remove rmw_connextdds entry from rmw_implementation"
-      ansible.builtin.replace:
-        path: "{{ ros_src_dir }}/rmw_implementation/package.xml"
-        regexp: .*rmw_connextdds.*\n
-      become: true
-    - stat:
-        path: /etc/ros/rosdep/sources.list.d/20-default.list
-      register: ros_sources_list_file
-    - name: "{{ block_name }}: rosdep init"
-      shell: rosdep init
-      become: true
-      when: not ros_sources_list_file.stat.exists
-    - name: "{{ block_name }}: rosdep update"
-      shell: rosdep update
-      become: true
-    - name: rosdep install
-      shell: rosdep install -y --ignore-src --from-paths src --rosdistro humble --skip-keys "libopencv-dev libopencv-contrib-dev libopencv-imgproc-dev python-opencv python3-opencv"
-      args:
-        chdir: "{{ ros_base_dir }}"
-      become: true
-    - name: "{{ block_name }}: correct file list under /var/lib/apt/lists"
-      ansible.builtin.find:
-        paths: /var/lib/apt/lists
-        hidden: true
-        recurse: true
-        file_type: any
-      register: file_under_var_lib_apt_lists
-    - name: "{{ block_name }}: remove all file under /var/lib/apt/lists"
-      ansible.builtin.file:
-        path: "{{ item.path }}"
-        state: absent
-      with_items: "{{ file_under_var_lib_apt_lists.files }}"
-      become: true
-    - name: "{{ block_name }}: apt-get clean"
-      ansible.builtin.apt:
-        clean: true
-      become: true
-    - name: "{{ block_name }}: apt-get purge pybind11-dev"
-      ansible.builtin.apt:
-        name: pybind11-dev
-        purge: true
-      become: true
-    - name: "{{ block_name }}: install pybind11-global"
-      ansible.builtin.pip:
-        name: pybind11-global
-        extra_args: -U
-      become: true
-    - name: "{{ block_name }}: apt-get purge libyaml-cpp-dev"
-      ansible.builtin.apt:
-        name: libyaml-cpp-dev
-        purge: true
-      become: true
-    - name: "{{ block_name }}: colcon build"
-      shell: colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=$(which python3.6)
-      args:
-        chdir: "{{ ros_base_dir }}"
-      become: true
-  vars:
-    block_name: Build ROS
-  when: not ros_build_dir_exist.stat.exists
-
-- name: Downgrade GCC as version 11 is too high for old CUDA version that is used in L4T
-  block:
-    - name: "{{ block_name }}: install gcc-8"
-      ansible.builtin.apt:
-        name:
-          - gcc-8
-          - g++-8
-        update_cache: true
-    - name: "{{ block_name }}: set gcc-8 as default"
-      community.general.alternatives:
-        name: gcc
-        path: /usr/bin/gcc-8
-        link: /usr/bin/gcc
-        state: selected
-        subcommands:
-          - name: g++
-            path: /usr/bin/g++-8
-            link: /usr/bin/g++
-  become: true
-  vars:
-    block_name: Downgrade gcc to 8
-
-- name: Add sourcing command in user's bashrc
-  ansible.builtin.blockinfile:
-    path: "{{ ansible_env.HOME }}/.bashrc"
-    state: present
-    marker: "# {mark} ros2"
-    block: |
-      source {{ ros_base_dir }}/install/setup.bash
-  when: not ros_build_dir_exist.stat.exists

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -57,12 +57,12 @@
 
 - name: Install dependencies
   block:
-#    - name: Install jetpack
-#      ansible.builtin.apt:
-#        name:
-#          - nvidia-jetpack
-#        install_recommends: false
-#        update_cache: true
+    #    - name: Install jetpack
+    #      ansible.builtin.apt:
+    #        name:
+    #          - nvidia-jetpack
+    #        install_recommends: false
+    #        update_cache: true
     - name: Install OpenCV deps
       ansible.builtin.command:
         cmd: "{{ opencv_install_deps_script }}"
@@ -113,12 +113,151 @@
   become: true
 
 - name: Build ROS2 Humble
-  ansible.builtin.command:
-    cmd: "{{ ros2_build_script }}"
-  environment:
-    ROS_DISTRO: "{{ ros_distro }}"
-    ROS_PKG: ros_base
-    ROS_ROOT: "/opt/ros/{{ ros_distro }}"
+  block:
+    - name: Add the ROS deb repo to the apt sources list
+      block:
+        - name: Install apt packages
+          ansible.builtin.apt:
+            name:
+              - curl
+              - wget
+              - gnupg2
+              - lsb-release
+              - ca-certificates
+            install_recommends: false
+            update_cache: true
+        - name: Download ros.key
+          ansible.builtin.command:
+            cmd: "curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg"
+        - name: "TODO: add name"
+          ansible.builtin.command:
+            cmd: 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null'
+    - name: Install apt packages
+      ansible.builtin.apt:
+        name:
+          - build-essential
+          - cmake
+          - git
+          - libbullet-dev
+          - libpython3-dev
+          - python3-colcon-common-extensions
+          - python3-flake8
+          - python3-pip
+          - python3-numpy
+          - python3-pytest-cov
+          - python3-rosdep
+          - python3-setuptools
+          - python3-vcstool
+          - python3-rosinstall-generator
+          - libasio-dev
+          - libtinyxml2-dev
+          - libcunit1-dev
+        install_recommends: false
+        update_cache: true
+    - name: Install pip packages
+      ansible.builtin.pip:
+        name:
+          - argcomplete
+          - flake8-blind-except
+          - flake8-builtins
+          - flake8-class-newline
+          - flake8-comprehensions
+          - flake8-deprecated
+          - flake8-docstrings
+          - flake8-import-order
+          - flake8-quotes
+          - pytest-repeat
+          - pytest-rerunfailures
+          - pytest
+          - scikit-build
+          - cmake
+        extra_args: "--upgrade --no-cache-dir"
+    - name: Create the ROS root directory and src directory
+      ansible.builtin.file:
+        path: "{{ ros_root_dir }}/src"
+        state: directory
+        recurse: true
+    - name: Download ROS packages
+      ansible.builtin.command:
+        cmd: >
+          "rosinstall_generator --deps --rosdistro ${ROS_DISTRO} ${ROS_PKG} 
+          launch_xml 
+          launch_yaml 
+          launch_testing 
+          launch_testing_ament_cmake 
+          demo_nodes_cpp 
+          demo_nodes_py 
+          example_interfaces 
+          camera_calibration_parsers 
+          camera_info_manager 
+          cv_bridge 
+          v4l2_camera 
+          vision_opencv 
+          vision_msgs 
+          image_geometry 
+          image_pipeline 
+          image_transport 
+          compressed_image_transport 
+          compressed_depth_image_transport 
+          pcl_msgs 
+          perception_pcl 
+          logging_demo 
+          udp_msgs 
+          angles 
+          diagnostics 
+          tf_transformations 
+          mrt_cmake_modules 
+          gtest_vendor 
+          grid_map 
+          filters 
+          nav2_msgs 
+          tf2-eigen 
+          ament_cmake_clang_format 
+          > ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall"
+    - name: Import packages to source directory
+      ansible.builtin.command:
+        cmd: "vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall"
+    - name: Install dependencies with rosdep
+      block:
+        - name: Initialize rosdep
+          ansible.builtin.command:
+            cmd: rosdep init
+        - name: Update rosdep
+          ansible.builtin.command:
+            cmd: rosdep update
+        - name: Run rosdep
+          ansible.builtin.command:
+            cmd: rosdep install -y --ignore-src --from-paths src --rosdistro {{ ros_distro }} --skip-keys {{ skip_keys }}
+    - name: Colcon build
+      ansible.builtin.command:
+        cmd: colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+    - name: Remove build files
+      block:
+        - name: Remove source directory
+          ansible.builtin.file:
+            path: "{{ ros_root_dir }}/src"
+            state: absent
+        - name: Remove log directory
+          ansible.builtin.file:
+            path: "{{ ros_root_dir }}/logs"
+            state: absent
+        - name: Remove build directory
+          ansible.builtin.file:
+            path: "{{ ros_root_dir }}/build"
+            state: absent
+        - name: Remove .rosinstall files
+          ansible.builtin.file:
+            path: "{{ ros_root_dir }}/*.rosinstall"
+            state: absent
+    - name: Clean up apt
+      block:
+        - name: Remove
+          ansible.builtin.file:
+            path: /var/lib/apt/lists/*
+            state: absent
+        - name: Apt-get clean
+          ansible.builtin.apt:
+            clean: true
   become: true
 
 - name: Install extra edge-auto-jetson dependency

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -77,40 +77,41 @@
         update_cache: true
   become: true
 
-- name: Install PCL
-  block:
-    - name: Define directory name
-      set_fact:
-        pcl_directory: "{{ ansible_env.HOME }}/pcl"
-    - name: Create build directory
-      ansible.builtin.file:
-        path: "{{ pcl_directory }}"
-        state: directory
-    - name: Download and extract PCL 1.12.1 source
-      ansible.builtin.unarchive:
-        src: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
-        dest: "{{ pcl_directory }}"
-        remote_src: yes
-    - name: Create build directory
-      ansible.builtin.file:
-        path: "{{ pcl_directory }}/pcl/build"
-        state: directory
-    - name: Run cmake
-      ansible.builtin.command:
-        cmd: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
-        chdir: "{{ pcl_directory }}/pcl/build"
-      environment:
-        PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
-    - name: Install PCL
-      ansible.builtin.command:
-        cmd: make -j7 install
-        chdir: "{{ pcl_directory }}/pcl/build"
-      become: true
-
-- name: Install OpenCV
-  ansible.builtin.command:
-    cmd: "{{ opencv_install_script }} https://nvidia.box.com/shared/static/2hssa5g3v28ozvo3tc3qwxmn78yerca9.gz OpenCV-4.5.0-aarch64.tar.gz"
-  become: true
+# for testing
+#- name: Install PCL
+#  block:
+#    - name: Define directory name
+#      set_fact:
+#        pcl_directory: "{{ ansible_env.HOME }}/pcl"
+#    - name: Create build directory
+#      ansible.builtin.file:
+#        path: "{{ pcl_directory }}"
+#        state: directory
+#    - name: Download and extract PCL 1.12.1 source
+#      ansible.builtin.unarchive:
+#        src: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
+#        dest: "{{ pcl_directory }}"
+#        remote_src: yes
+#    - name: Create build directory
+#      ansible.builtin.file:
+#        path: "{{ pcl_directory }}/pcl/build"
+#        state: directory
+#    - name: Run cmake
+#      ansible.builtin.command:
+#        cmd: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
+#        chdir: "{{ pcl_directory }}/pcl/build"
+#      environment:
+#        PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
+#    - name: Install PCL
+#      ansible.builtin.command:
+#        cmd: make -j7 install
+#        chdir: "{{ pcl_directory }}/pcl/build"
+#      become: true
+#
+#- name: Install OpenCV
+#  ansible.builtin.command:
+#    cmd: "{{ opencv_install_script }} https://nvidia.box.com/shared/static/2hssa5g3v28ozvo3tc3qwxmn78yerca9.gz OpenCV-4.5.0-aarch64.tar.gz"
+#  become: true
 
 - name: Build ROS2 Humble
   block:
@@ -132,6 +133,7 @@
         - name: "TODO: add name"
           ansible.builtin.command:
             cmd: 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null'
+      become: true
     - name: Install apt packages
       ansible.builtin.apt:
         name:
@@ -140,7 +142,7 @@
           - git
           - libbullet-dev
           - libpython3-dev
-          - python3-colcon-common-extensions
+#          - python3-colcon-common-extensions
           - python3-flake8
           - python3-pip
           - python3-numpy
@@ -152,11 +154,15 @@
           - libasio-dev
           - libtinyxml2-dev
           - libcunit1-dev
+          - apt-utils
         install_recommends: false
         update_cache: true
+      become: true
     - name: Install pip packages
       ansible.builtin.pip:
         name:
+          - colcon-common-extensions
+          - catkin-pkg-modules
           - argcomplete
           - flake8-blind-except
           - flake8-builtins
@@ -172,67 +178,53 @@
           - scikit-build
           - cmake
         extra_args: "--upgrade --no-cache-dir"
+    - name: Could NOT find Python3 workaround
+      ansible.builtin.apt:
+        name:
+          - python3.9
+          - libpython3.9*
+        purge: true
+        state: absent
+      become: true
     - name: Create the ROS root directory and src directory
       ansible.builtin.file:
         path: "{{ ros_root_dir }}/src"
         state: directory
         recurse: true
+      become: true
+#    - name: Create .rosinstall file to hold ROS packages
+#      ansible.builtin.file:
+#        path: ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall
+#        state: touch
     - name: Download ROS packages
-      ansible.builtin.command:
-        cmd: >
-          "rosinstall_generator --deps --rosdistro ${ROS_DISTRO} ${ROS_PKG} 
-          launch_xml 
-          launch_yaml 
-          launch_testing 
-          launch_testing_ament_cmake 
-          demo_nodes_cpp 
-          demo_nodes_py 
-          example_interfaces 
-          camera_calibration_parsers 
-          camera_info_manager 
-          cv_bridge 
-          v4l2_camera 
-          vision_opencv 
-          vision_msgs 
-          image_geometry 
-          image_pipeline 
-          image_transport 
-          compressed_image_transport 
-          compressed_depth_image_transport 
-          pcl_msgs 
-          perception_pcl 
-          logging_demo 
-          udp_msgs 
-          angles 
-          diagnostics 
-          tf_transformations 
-          mrt_cmake_modules 
-          gtest_vendor 
-          grid_map 
-          filters 
-          nav2_msgs 
-          tf2-eigen 
-          ament_cmake_clang_format 
-          > ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall"
+      ansible.builtin.shell:
+        cmd: "rosinstall_generator --deps --rosdistro {{ ros_distro }} {{ ros_pkg }} launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge v4l2_camera vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl logging_demo udp_msgs angles diagnostics tf_transformations mrt_cmake_modules gtest_vendor grid_map filters nav2_msgs tf2-eigen ament_cmake_clang_format > {{ ros_root_dir }}/ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall"
+      become: true
     - name: Import packages to source directory
-      ansible.builtin.command:
-        cmd: "vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall"
+      ansible.builtin.shell:
+        cmd: "vcs import src < ros2.humble.ros_base.rosinstall"
+        chdir: "{{ ros_root_dir }}"
+      become: true
     - name: Install dependencies with rosdep
       block:
-        - name: Initialize rosdep
-          ansible.builtin.command:
-            cmd: rosdep init
         - name: Update rosdep
-          ansible.builtin.command:
+          ansible.builtin.shell:
             cmd: rosdep update
         - name: Run rosdep
-          ansible.builtin.command:
-            cmd: rosdep install -y --ignore-src --from-paths src --rosdistro {{ ros_distro }} --skip-keys {{ skip_keys }}
+          shell: "rosdep install -y --ignore-src --from-paths src --rosdistro humble --skip-keys 'libopencv-dev python3-catkin-pkg-modules python3-rosdistro-modules libignition-math6-dev rti-connext-dds-6.0.1 ignition-math6'"
+          args:
+            chdir: "{{ ros_root_dir }}"
     - name: Colcon build
       ansible.builtin.command:
         cmd: colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+        chdir: "{{ ros_root_dir }}"
+      become: true
     - name: Remove build files
       block:
+        - name: Remove .rosinstall file
+          ansible.builtin.file:
+            path: ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall
+            state: absent
         - name: Remove source directory
           ansible.builtin.file:
             path: "{{ ros_root_dir }}/src"
@@ -249,6 +241,7 @@
           ansible.builtin.file:
             path: "{{ ros_root_dir }}/*.rosinstall"
             state: absent
+      become: true
     - name: Clean up apt
       block:
         - name: Remove
@@ -258,7 +251,7 @@
         - name: Apt-get clean
           ansible.builtin.apt:
             clean: true
-  become: true
+      become: true
 
 - name: Install extra edge-auto-jetson dependency
   ansible.builtin.apt:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -123,18 +123,18 @@
         remote_src: yes
     - name: Create build directory
       ansible.builtin.file:
-        path: "{{ range_v3_directory }}/range-v3/build"
+        path: "{{ range_v3_directory }}/range-v3-0.11.0/build"
         state: directory
     - name: Run cmake
       ansible.builtin.command:
         cmd: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
-        chdir: "{{ range_v3_directory }}/range-v3/build"
+        chdir: "{{ range_v3_directory }}/range-v3-0.11.0/build"
       environment:
         PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
     - name: Install range-v3
       ansible.builtin.command:
         cmd: make -j7 install
-        chdir: "{{ range_v3_directory }}/range-v3/build"
+        chdir: "{{ range_v3_directory }}/range-v3-0.11.0/build"
       become: true
 
 - name: Build ROS2 Humble

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -161,12 +161,12 @@
     - name: Install apt packages
       ansible.builtin.apt:
         name:
+          - apt-utils
           - build-essential
           - cmake
           - git
           - libbullet-dev
           - libpython3-dev
-          #          - python3-colcon-common-extensions
           - python3-flake8
           - python3-pip
           - python3-numpy
@@ -182,7 +182,6 @@
           - libgeographic-dev
           - libgtest-dev
           - libcgal-dev
-          - apt-utils
         install_recommends: false
         update_cache: true
       become: true
@@ -220,10 +219,6 @@
         state: directory
         recurse: true
       become: true
-    #    - name: Create .rosinstall file to hold ROS packages
-    #      ansible.builtin.file:
-    #        path: ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall
-    #        state: touch
     - name: Download ROS packages
       ansible.builtin.shell:
         cmd: "rosinstall_generator --deps --rosdistro {{ ros_distro }} {{ ros_pkg }} launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge v4l2_camera vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl logging_demo udp_msgs angles diagnostics tf_transformations mrt_cmake_modules gtest_vendor grid_map filters nav2_msgs tf2-eigen ament_cmake_clang_format > {{ ros_root_dir }}/ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall"

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -57,12 +57,12 @@
 
 - name: Install dependencies
   block:
-    - name: Install jetpack
-      ansible.builtin.apt:
-        name:
-          - nvidia-jetpack
-        install_recommends: false
-        update_cache: true
+#    - name: Install jetpack
+#      ansible.builtin.apt:
+#        name:
+#          - nvidia-jetpack
+#        install_recommends: false
+#        update_cache: true
     - name: Install OpenCV deps
       ansible.builtin.command:
         cmd: "{{ opencv_install_deps_script }}"

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -34,14 +34,26 @@
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/opencv_install_deps.sh
         dest: "{{ opencv_install_deps_script }}"
+    - name: Make OpenCV deps script executable
+      ansible.builtin.file:
+        dest: "{{ opencv_install_deps_script }}"
+        mode: u+x
     - name: Download OpenCV install script
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/opencv_install.sh
         dest: "{{ opencv_install_script }}"
+    - name: Make OpenCV install script executable
+      ansible.builtin.file:
+        dest: "{{ opencv_install_script }}"
+        mode: u+x
     - name: Download ROS2 Humble install script
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/dusty-nv/jetson-containers/L4T-R35.3.1/scripts/ros2_build.sh
         dest: "{{ ros2_build_script }}"
+    - name: Make ROS2 Humble install script executable
+      ansible.builtin.file:
+        dest: "{{ ros2_build_script }}"
+        mode: u+x
 
 - name: Install dependencies
   block:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -109,7 +109,7 @@
 
 - name: Install OpenCV
   ansible.builtin.command:
-    cmd: "{{ opencv_install_script }} {{ opencv_url }} {{ opencv_deb }}"
+    cmd: "{{ opencv_install_script }} https://nvidia.box.com/shared/static/2hssa5g3v28ozvo3tc3qwxmn78yerca9.gz OpenCV-4.5.0-aarch64.tar.gz"
 
 - name: Build ROS2 Humble
   ansible.builtin.command:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -178,6 +178,10 @@
           - libasio-dev
           - libtinyxml2-dev
           - libcunit1-dev
+          - libpugixml-dev
+          - libgeographic-dev
+          - libgtest-dev
+          - libcgal-dev
           - apt-utils
         install_recommends: false
         update_cache: true

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -57,12 +57,6 @@
 
 - name: Install dependencies
   block:
-    #    - name: Install jetpack
-    #      ansible.builtin.apt:
-    #        name:
-    #          - nvidia-jetpack
-    #        install_recommends: false
-    #        update_cache: true
     - name: Install OpenCV deps
       ansible.builtin.command:
         cmd: "{{ opencv_install_deps_script }}"
@@ -73,45 +67,75 @@
           - libboost-filesystem-dev
           - libboost-date-time-dev
           - libboost-iostreams-dev
+          - libvtk7-dev
         install_recommends: false
         update_cache: true
   become: true
 
-# for testing
-#- name: Install PCL
-#  block:
-#    - name: Define directory name
-#      set_fact:
-#        pcl_directory: "{{ ansible_env.HOME }}/pcl"
-#    - name: Create build directory
-#      ansible.builtin.file:
-#        path: "{{ pcl_directory }}"
-#        state: directory
-#    - name: Download and extract PCL 1.12.1 source
-#      ansible.builtin.unarchive:
-#        src: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
-#        dest: "{{ pcl_directory }}"
-#        remote_src: yes
-#    - name: Create build directory
-#      ansible.builtin.file:
-#        path: "{{ pcl_directory }}/pcl/build"
-#        state: directory
-#    - name: Run cmake
-#      ansible.builtin.command:
-#        cmd: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
-#        chdir: "{{ pcl_directory }}/pcl/build"
-#      environment:
-#        PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
-#    - name: Install PCL
-#      ansible.builtin.command:
-#        cmd: make -j7 install
-#        chdir: "{{ pcl_directory }}/pcl/build"
-#      become: true
-#
-#- name: Install OpenCV
-#  ansible.builtin.command:
-#    cmd: "{{ opencv_install_script }} https://nvidia.box.com/shared/static/2hssa5g3v28ozvo3tc3qwxmn78yerca9.gz OpenCV-4.5.0-aarch64.tar.gz"
-#  become: true
+- name: Install PCL
+  block:
+    - name: Define directory name
+      set_fact:
+        pcl_directory: "{{ ansible_env.HOME }}/pcl"
+    - name: Create build directory
+      ansible.builtin.file:
+        path: "{{ pcl_directory }}"
+        state: directory
+    - name: Download and extract PCL 1.12.1 source
+      ansible.builtin.unarchive:
+        src: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
+        dest: "{{ pcl_directory }}"
+        remote_src: yes
+    - name: Create build directory
+      ansible.builtin.file:
+        path: "{{ pcl_directory }}/pcl/build"
+        state: directory
+    - name: Run cmake
+      ansible.builtin.command:
+        cmd: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
+        chdir: "{{ pcl_directory }}/pcl/build"
+      environment:
+        PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
+    - name: Install PCL
+      ansible.builtin.command:
+        cmd: make -j7 install
+        chdir: "{{ pcl_directory }}/pcl/build"
+      become: true
+
+- name: Install OpenCV
+  ansible.builtin.command:
+    cmd: "{{ opencv_install_script }} https://nvidia.box.com/shared/static/2hssa5g3v28ozvo3tc3qwxmn78yerca9.gz OpenCV-4.5.0-aarch64.tar.gz"
+  become: true
+
+- name: Install range-v3 0.11.0
+  block:
+    - name: Define directory name
+      set_fact:
+        range_v3_directory: "{{ ansible_env.HOME }}/range-v3"
+    - name: Create build directory
+      ansible.builtin.file:
+        path: "{{ range_v3_directory }}"
+        state: directory
+    - name: Download and extract range-v3 0.11.0 source
+      ansible.builtin.unarchive:
+        src: https://github.com/ericniebler/range-v3/archive/refs/tags/0.11.0.tar.gz
+        dest: "{{ range_v3_directory }}"
+        remote_src: yes
+    - name: Create build directory
+      ansible.builtin.file:
+        path: "{{ range_v3_directory }}/range-v3/build"
+        state: directory
+    - name: Run cmake
+      ansible.builtin.command:
+        cmd: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc ..
+        chdir: "{{ range_v3_directory }}/range-v3/build"
+      environment:
+        PATH: "/usr/local/cuda/bin:{{ ansible_env.PATH }}"
+    - name: Install range-v3
+      ansible.builtin.command:
+        cmd: make -j7 install
+        chdir: "{{ range_v3_directory }}/range-v3/build"
+      become: true
 
 - name: Build ROS2 Humble
   block:
@@ -142,7 +166,7 @@
           - git
           - libbullet-dev
           - libpython3-dev
-#          - python3-colcon-common-extensions
+          #          - python3-colcon-common-extensions
           - python3-flake8
           - python3-pip
           - python3-numpy
@@ -192,10 +216,10 @@
         state: directory
         recurse: true
       become: true
-#    - name: Create .rosinstall file to hold ROS packages
-#      ansible.builtin.file:
-#        path: ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall
-#        state: touch
+    #    - name: Create .rosinstall file to hold ROS packages
+    #      ansible.builtin.file:
+    #        path: ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall
+    #        state: touch
     - name: Download ROS packages
       ansible.builtin.shell:
         cmd: "rosinstall_generator --deps --rosdistro {{ ros_distro }} {{ ros_pkg }} launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge v4l2_camera vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl logging_demo udp_msgs angles diagnostics tf_transformations mrt_cmake_modules gtest_vendor grid_map filters nav2_msgs tf2-eigen ament_cmake_clang_format > {{ ros_root_dir }}/ros2.{{ ros_distro }}.{{ ros_pkg }}.rosinstall"

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -110,6 +110,7 @@
 - name: Install OpenCV
   ansible.builtin.command:
     cmd: "{{ opencv_install_script }} https://nvidia.box.com/shared/static/2hssa5g3v28ozvo3tc3qwxmn78yerca9.gz OpenCV-4.5.0-aarch64.tar.gz"
+  become: true
 
 - name: Build ROS2 Humble
   ansible.builtin.command:
@@ -118,6 +119,7 @@
     ROS_DISTRO: "{{ ros_distro }}"
     ROS_PKG: ros_base
     ROS_ROOT: "/opt/ros/{{ ros_distro }}"
+  become: true
 
 - name: Install extra edge-auto-jetson dependency
   ansible.builtin.apt:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -84,10 +84,11 @@
         pcl_directory: "{{ ansible_env.HOME }}/pcl"
     - name: Create build directory
       ansible.builtin.file:
-        path: pcl_directory
+        path: "{{ pcl_directory }}"
+        state: directory
     - name: Download and extract PCL 1.12.1 source
       ansible.builtin.unarchive:
-        url: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
+        src: https://github.com/PointCloudLibrary/pcl/releases/download/pcl-1.12.1/source.tar.gz
         dest: "{{ pcl_directory }}"
         remote_src: yes
     - name: Create build directory

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -30,6 +30,8 @@
     - role: ros2
     - role: ptp4l_client
       when: prompt_configure_network == 'y'
+    - role: ptp4l_host
+      when: prompt_configure_network == 'y'
     - role: enlarge_txqueue
       when: prompt_configure_network == 'y'
     - role: netplan

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -5,15 +5,15 @@
     - network_config:
         ros:
           interface_address: 192.168.2.2
-          interface_name: eth1
+          interface_name: mgbe0
         dhcp:
-          interface_name: eth0
-    - ptp4l_client_interface: eth1
+          interface_name: mgbe1
+    - ptp4l_client_interface: mgbe0
   vars_prompt:
-    - name: prompt_install_camera_driver
-      prompt: |-
-        [Warning] Do you want to install/update the TIER IV camera driver? [y/N]
-      private: false
+#    - name: prompt_install_camera_driver
+#      prompt: |-
+#        [Warning] Do you want to install/update the TIER IV camera driver? [y/N]
+#      private: false
     - name: prompt_configure_network
       prompt: |-
         [Warning] Do you want to configure the network? This configuration may overwrite the IP address of the specific network interface [y/N]
@@ -22,11 +22,11 @@
     - role: autoware
     - role: cuda
     - role: cyclonedds
-    - role: docker
+#    - role: docker
     - role: vcstool
     - role: calibration_tools
-    - role: tier4_hdr_camera_driver
-      when: prompt_install_camera_driver == 'y'
+#    - role: tier4_hdr_camera_driver
+#      when: prompt_install_camera_driver == 'y'
     - role: ros2
     - role: ptp4l_client
       when: prompt_configure_network == 'y'

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -18,6 +18,10 @@
       prompt: |-
         [Warning] Do you want to configure the network? This configuration may overwrite the IP address of the specific network interface [y/N]
       private: false
+    - name: prompt_download_models
+      prompt: |-
+        [Warning] Do you want to download onnx models? [y/N]
+      private: false
   roles:
     - role: autoware
     - role: cuda
@@ -30,6 +34,8 @@
       when: prompt_configure_network == 'y'
     - role: netplan
       when: prompt_configure_network == 'y'
+    - role: download_models
+      when: prompt_download_models == 'y'
 
   environment:
     DEBIAN_FRONTEND: noninteractive

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -8,7 +8,11 @@
           interface_name: eqos0
         dhcp:
           interface_name: mgbe1
+        lidar:
+          interface_address: 192.168.1.100
+          interface_name: mgbe0
     - ptp4l_client_interface: eqos0
+    - ptp4l_host_interface: mgbe0
   vars_prompt:
 #    - name: prompt_install_camera_driver
 #      prompt: |-

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -10,9 +10,9 @@
           interface_name: mgbe1
         lidar:
           interface_address: 192.168.1.100
-          interface_name: mgbe0
+          interface_name: eth0
     - ptp4l_client_interface: eqos0
-    - ptp4l_host_interface: mgbe0
+    - ptp4l_host_interface: eth0
   vars_prompt:
 #    - name: prompt_install_camera_driver
 #      prompt: |-

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -24,7 +24,7 @@
     - role: cyclonedds
 #    - role: docker
     - role: vcstool
-    - role: calibration_tools
+#    - role: calibration_tools
 #    - role: tier4_hdr_camera_driver
 #      when: prompt_install_camera_driver == 'y'
     - role: ros2

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -32,8 +32,8 @@
 #    - role: tier4_hdr_camera_driver
 #      when: prompt_install_camera_driver == 'y'
     - role: ros2
-    - role: ptp4l_client
-      when: prompt_configure_network == 'y'
+#    - role: ptp4l_client
+#      when: prompt_configure_network == 'y'
     - role: ptp4l_host
       when: prompt_configure_network == 'y'
     - role: enlarge_txqueue

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -5,10 +5,10 @@
     - network_config:
         ros:
           interface_address: 192.168.2.2
-          interface_name: mgbe0
+          interface_name: eqos0
         dhcp:
           interface_name: mgbe1
-    - ptp4l_client_interface: mgbe0
+    - ptp4l_client_interface: eqos0
   vars_prompt:
 #    - name: prompt_install_camera_driver
 #      prompt: |-

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -14,10 +14,6 @@
     - ptp4l_client_interface: eqos0
     - ptp4l_host_interface: eth0
   vars_prompt:
-#    - name: prompt_install_camera_driver
-#      prompt: |-
-#        [Warning] Do you want to install/update the TIER IV camera driver? [y/N]
-#      private: false
     - name: prompt_configure_network
       prompt: |-
         [Warning] Do you want to configure the network? This configuration may overwrite the IP address of the specific network interface [y/N]
@@ -26,14 +22,8 @@
     - role: autoware
     - role: cuda
     - role: cyclonedds
-#    - role: docker
     - role: vcstool
-#    - role: calibration_tools
-#    - role: tier4_hdr_camera_driver
-#      when: prompt_install_camera_driver == 'y'
     - role: ros2
-#    - role: ptp4l_client
-#      when: prompt_configure_network == 'y'
     - role: ptp4l_host
       when: prompt_configure_network == 'y'
     - role: enlarge_txqueue

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -34,3 +34,6 @@
       when: prompt_configure_network == 'y'
     - role: netplan
       when: prompt_configure_network == 'y'
+
+  environment:
+    DEBIAN_FRONTEND: noninteractive

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -11,10 +11,10 @@ if ! (command -v sudo >/dev/null 2>&1); then
 fi
 
 # Disable inactive apt repository
-DISABLE_TARGET="/etc/apt/sources.list.d/roscube.list"
-if [ -e ${DISABLE_TARGET} ]; then
-    sudo sed -i 's/.*neuron\.adlinktech\.com.*/# &/g' ${DISABLE_TARGET}
-fi
+# DISABLE_TARGET="/etc/apt/sources.list.d/roscube.list"
+# if [ -e ${DISABLE_TARGET} ]; then
+#     sudo sed -i 's/.*neuron\.adlinktech\.com.*/# &/g' ${DISABLE_TARGET}
+# fi
 
 # Install git
 if ! (command -v git >/dev/null 2>&1); then

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -10,12 +10,6 @@ if ! (command -v sudo >/dev/null 2>&1); then
     apt-get -y install sudo
 fi
 
-# Disable inactive apt repository
-# DISABLE_TARGET="/etc/apt/sources.list.d/roscube.list"
-# if [ -e ${DISABLE_TARGET} ]; then
-#     sudo sed -i 's/.*neuron\.adlinktech\.com.*/# &/g' ${DISABLE_TARGET}
-# fi
-
 # Install git
 if ! (command -v git >/dev/null 2>&1); then
     sudo apt-get -y update


### PR DESCRIPTION
## Description

This PR fixes edge-auto-jetson `anvil-dev` branch to align with Autoware Universe's new model download logic. **This PR depends on [this PR](https://github.com/tier4/edge_auto_jetson_launch/pull/10) in edge_auto_jetson_launch**

## Related Links
- https://github.com/autowarefoundation/autoware.universe/issues/3137
- https://github.com/tier4/edge_auto_jetson_launch/pull/10

## Tests performed

None.

## Effects on system behavior

Previously, edge-auto's model downloading was broken by an update to Autoware Universe, such that YOLOX and Centerpoint would not be able to launch. This PR updates edge-auto-jetson `anvil-dev` to correctly download models under Autoware Universe's new scheme.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
