### PR TITLE
fix: add launch_pytest to rosinstall argument to fix build errors in …

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -339,7 +339,7 @@
         state: directory
       become: true
     - name: "{{ block_name }}: generate repository list using rosinstall_generator"
-      shell: rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
+      shell: rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl launch_pytest --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
     - name: "{{ block_name }}: copy repository list to target ddirectory"
       ansible.builtin.copy:
         src: /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall


### PR DESCRIPTION
## Environment
Ubuntu 18.04
ADLINK RQX-58G (L4T R32.6.1)
R32 (release), REVISION: 6.1, GCID: 27863751, BOARD: t186ref, EABI: aarch64, DATE: Mon Jul 26 19:36:31 UTC 2021

## Description

<!-- Write a brief description of this PR. -->

I ran `./setup-dev-env.sh` to setting up a new roscube and got the following error.

```
TASK [ros2 : rosdep install] ***************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "rosdep install -y --ignore-src --from-paths src --rosdistro humble --skip-keys \"libopencv-dev libopencv-contrib-dev libopencv-imgproc-dev python-opencv python3-opencv\"", "delta": "0:00:13.080717", "end": "2024-03-22 14:16:21.890241", "msg": "non-zero return code", "rc": 1, "start": "2024-03-22 14:16:08.809524", 
"stderr": "ERROR: the following packages/stacks could not have their rosdep keys resolved\nto system dependencies:\ndiagnostic_aggregator: No definition of [launch_pytest] for OS version [bionic]", "stderr_lines": ["ERROR: the following packages/stacks could not have their rosdep keys resolved", "to system dependencies:", "diagnostic_aggregator: No definition of [launch_pytest] for OS version [bionic]"], "stdout": "", "stdout_lines": []}
```

To fix this, I added `launch_pytest` to rosinstall argument to fix build errors in ros2.

```
rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl launch_pytest --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
```

## Tests performed
Build was succesful in my environment.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

…ros2

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
