### PR TITLE
fix: specify pybind11-global version 2.11.1

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -411,7 +411,7 @@
       become: true
     - name: "{{ block_name }}: install pybind11-global"
       ansible.builtin.pip:
-        name: pybind11-global
+        name: pybind11-global==2.11.1
         extra_args: -U
       become: true
     - name: "{{ block_name }}: apt-get purge libyaml-cpp-dev"


### PR DESCRIPTION
## Environment
Ubuntu 18.04
ADLINK RQX-58G (L4T R32.6.1)
R32 (release), REVISION: 6.1, GCID: 27863751, BOARD: t186ref, EABI: aarch64, DATE: Mon Jul 26 19:36:31 UTC 2021

## Description
When I ran ./setup-dev-env.sh for setup, couldn't complement ros2 command in command line. 
I specify pybind11-global version 2.11.1 in [here](https://github.com/softyanija/edge-auto-jetson/blob/0bb2076b6985a9defeb7f10fc3f2dd7c31fe2876/ansible/roles/ros2/tasks/main.yaml#L412-L414) with the help of https://github.com/tier4/autoware_ecu_system_setup/pull/964 and the problem was solved.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tab complementation was successed.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
