### PR TITLE
fix(ansible): enable ansible cuda run multiple times

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -6,6 +6,11 @@
     state: absent
     purge: true
 
+- name: Remove OpenCV build directory
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/source_builds/jetson-containers"
+    state: absent
+
 - name: Install apt packages
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -1,9 +1,14 @@
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: apt
+
 - name: Install apt packages
   become: true
   ansible.builtin.apt:
     name:
       - nvidia-jetpack
     update_cache: true
+  when: "'nvidia-jetpack' not in ansible_facts.package"
 
 - name: Add settings to autoware.env
   ansible.builtin.blockinfile:

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -1,6 +1,10 @@
-- name: Gather package facts
-  ansible.builtin.package_facts:
-    manager: apt
+- name: Remove OpenCV installation
+  become: true
+  ansible.builtin.apt:
+    name:
+      - "*opencv"
+    state: absent
+    purge: true
 
 - name: Install apt packages
   become: true
@@ -8,7 +12,6 @@
     name:
       - nvidia-jetpack
     update_cache: true
-  when: "'nvidia-jetpack' not in ansible_facts.package"
 
 - name: Add settings to autoware.env
   ansible.builtin.blockinfile:


### PR DESCRIPTION
## Description

Previously ansible script gives error related to jetpack installation if run multiple times due to incoherence with cuda/opencv

## Tests performed

Ran ansible multiple times successfully.

## Effects on system behavior

Allows ansible to be run multiple times without error


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
