### PR TITLE
fix: add ament_cmake_clang_format and loging_demo to rosinstall_gener…

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -339,7 +339,7 @@
         state: directory
       become: true
     - name: "{{ block_name }}: generate repository list using rosinstall_generator"
-      shell: rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl launch_pytest --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
+      shell: rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl launch_pytest ament_cmake_clang_format logging_demo --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
     - name: "{{ block_name }}: copy repository list to target ddirectory"
       ansible.builtin.copy:
         src: /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall


### PR DESCRIPTION
## Environment
Ubuntu 18.04
ADLINK RQX-58G (L4T R32.6.1)
R32 (release), REVISION: 6.1, GCID: 27863751, BOARD: t186ref, EABI: aarch64

## Description
I ran `rosdep install -y --from-paths colcon list --packages-up-to edge_auto_jetson_launch -p --ignore-src --skip-keys autoware_launch` to setup ECU, and got the following error.
```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
intrinsic_camera_calibrator: [python3-pyside2.qtquick] defined as "not available" for OS version [bionic]
sensor_trigger: No definition of [ament_cmake_clang_format] for OS version [bionic]
tier4_autoware_utils: No definition of [logging_demo] for OS version [bionic]
```
To fix thiss, I added ament_`cmake_clang_format` and `logging_demo` to rosinstall argument to fix error.
```
rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl launch_pytest ament_cmake_clang_format logging_demo --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
```
I addressed bag about  `intrinsic_camera_calibrator` by deleting it in  https://github.com/tier4/edge_auto_jetson_launch.xx1/commit/cbe4138ce5d2758ae2b782e6783c4f5270885b6d. (this is private repository)

## Tests performed
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Build was succesful in my environment.


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
