### PR TITLE
added autoware_internal_msgs to autoware.repos because it is needed d…

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -41,6 +41,10 @@ repositories:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
+  autoware_internal_msgs
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: main
   image_pipeline:
     type: git
     url: https://github.com/tier4/image_pipeline.git


### PR DESCRIPTION
## Environment
Ubuntu 18.04
ADLINK RQX-58G (L4T R32.6.1)
R32 (release), REVISION: 6.1, GCID: 27863751, BOARD: t186ref, EABI: aarch64

## Description
I ran edge-auto-jetson.launch.xml in [here](https://github.com/tier4/edge_auto_jetson_launch.xx1/tree/main/edge_auto_jetson_launch/launch) and `autoware_internal_msgs` was missing. The reason is presumed to be autoware pository changes. Then, I added autoware_internal_msgs package to `autoware.repos`. 

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
