### PR TITLE
fix: update edge_auto_launcher tasks

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -152,6 +152,8 @@
     "soruce",
     "TIERIV",
     "txqueue",
-    "txqueuelen"
+    "txqueuelen",
+    "semseg",
+    "adlinktech"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -154,6 +154,7 @@
     "txqueue",
     "txqueuelen",
     "semseg",
-    "adlinktech"
+    "adlinktech",
+    "covdep"
   ]
 }

--- a/ansible/roles/artifacts/defaults/main.yaml
+++ b/ansible/roles/artifacts/defaults/main.yaml
@@ -1,0 +1,1 @@
+script_download_dir: /tmp

--- a/ansible/roles/artifacts/defaults/main.yaml
+++ b/ansible/roles/artifacts/defaults/main.yaml
@@ -1,1 +1,1 @@
-script_download_dir: /tmp
+artifacts_script_download_dir: /tmp

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -1,0 +1,80 @@
+# tensorrt_yolox
+- name: Create tensorrt_yolox directory inside {{ data_dir }}
+  ansible.builtin.file:
+    path: "{{ data_dir }}/tensorrt_yolox"
+    mode: "755"
+    state: directory
+
+- name: Download tensorrt_yolox/yolox-tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-tiny.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-tiny.onnx"
+    mode: "644"
+    checksum: sha256:471a665f4243e654dff62578394e508db22ee29fe65d9e389dfc3b0f2dee1255
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.onnx"
+    mode: "644"
+    checksum: sha256:36b0832177b01e6b278e00c7369f1de71e616c36261cbae50f0753d41289da01
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: sha256:b9e9d7da33342262ccaea4469b4d02b8abb32b6d7bf737f9e0883fece1b8f580
+
+- name: Download tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_yolox_s/v1/yolox-sPlus-T4-960x960-pseudo-finetune.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.onnx"
+    mode: "644"
+    checksum: sha256:f5054e8a890c3be86dc1b4b89a5a36fb2279d4f6110b0159e793be062641bf65
+
+- name: Download tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_yolox_s/v1/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: sha256:cc378d327db5616b0b3a4d077bf37100c25a50ecd22d2b542f54098da100f34c
+
+- name: Download tensorrt_yolox/label.txt
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/label.txt
+    dest: "{{ data_dir }}/tensorrt_yolox/label.txt"
+    mode: "644"
+    checksum: sha256:3540a365bfd6d8afb1b5d8df4ec47f82cb984760d3270c9b41dbbb3422d09a0c
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx"
+    mode: "644"
+    checksum: sha256:73b3812432cedf65cebf02ca4cb630542fc3b1671c4c0fbf7cee50fa38e416a8
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: sha256:28cd6524d4bcdb2809592a225d28330433e58dc02c92169ea555b44c1a51a584
+
+- name: Download tensorrt_yolox/semseg_color_map.csv
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/semseg_color_map.csv
+    dest: "{{ data_dir }}/tensorrt_yolox/semseg_color_map.csv"
+    mode: "644"
+    checksum: sha256:3d93ca05f31b63424d7d7246a01a2365953705a0ed3323ba5b6fddd744a4bfea
+
+

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -76,5 +76,3 @@
     dest: "{{ data_dir }}/tensorrt_yolox/semseg_color_map.csv"
     mode: "644"
     checksum: sha256:3d93ca05f31b63424d7d7246a01a2365953705a0ed3323ba5b6fddd744a4bfea
-
-

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -269,23 +269,16 @@
 - name: Upgrade CMake
   block:
     # Follow drirections here: https://apt.kitware.com/
+    - name: "{{ block_name }}: update gpg key"
+      shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
     - name: "{{ block_name }}: update repository info"
       ansible.builtin.apt_repository:
         repo: deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ {{ ansible_distribution_release }} main
         filename: kitware
-    - name: "{{ block_name }}: delete gpg key"
-      ansible.builtin.file:
-        path: /usr/share/keyrings/kitware-archive-keyring.gpg
-        state: absent
-    - name: "{{ block_name }}: update gpg key"
-      shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
     - name: "{{ block_name }}: apt update"
       ansible.builtin.apt:
         update_cache: true
         state: present
-    - name: "{{ block_name }}: install kitware-archive-keyring"
-      ansible.builtin.apt:
-        name: kitware-archive-keyring
     - name: "{{ block_name }}: install newer cmake"
       ansible.builtin.apt:
         name: cmake

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -17,32 +17,33 @@
           - apt-transport-https
         install_recommends: false
         update_cache: true
-    - name: Add ROS 2 source list
-      shell: echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-    - name: Download gpg key
-      ansible.builtin.uri:
-        url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
-        dest: /usr/share/keyrings/ros-archive-keyring.gpg
-        follow_redirects: all
+    # - name: Add ROS 2 source list
+    #   shell: echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+    # - name: Download gpg key
+    #   ansible.builtin.uri:
+    #     url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
+    #     dest: /usr/share/keyrings/ros-archive-keyring.gpg
+    #     follow_redirects: all
     - name: Apt install
       ansible.builtin.apt:
         name:
           - nvidia-jetpack
+          - nvidia-opencv
           - build-essential
           - cmake
           - git
           - libbullet-dev
           - libpython3-dev
           - python3-wheel
-          - python3-colcon-common-extensions
+          # - python3-colcon-common-extensions
           - python3-flake8
           - python3-pip
           - python3-numpy
           - python3-pytest-cov
-          - python3-rosdep
+          # - python3-rosdep
           - python3-setuptools
-          - python3-vcstool
-          - python3-rosinstall-generator
+          # - python3-vcstool
+          # - python3-rosinstall-generator
           - libasio-dev
           - libtinyxml2-dev
           - libcunit1-dev
@@ -74,6 +75,10 @@
       - pytest
       - pybind11-global
       - importlib_resources
+      - rosdep
+      - vcstool
+      - colcon-common-extensions
+      - rosinstall-generator
     extra_args: -U
   become: true # need to sudo privilege to install packages globally
 
@@ -209,26 +214,26 @@
     path: "{{ source_build_dir }}/jetson-containers"
   register: opencv_build_dir_exist
 
-- name: Build and install OpenCV
-  block:
-    - name: "{{ block_name }}: Download install script"
-      ansible.builtin.git:
-        repo: https://github.com/dusty-nv/jetson-containers.git
-        dest: "{{ source_build_dir }}/jetson-containers"
-        version: L4T-R35.1.0
-    - name: "{{ block_name }}: install dependencies"
-      shell: ./opencv_install_deps.sh
-      args:
-        chdir: "{{ source_build_dir }}/jetson-containers/scripts"
-      become: true
-    - name: "{{ block_name }}: execute install script"
-      shell: ./opencv_install.sh https://nvidia.box.com/shared/static/5v89u6g5rb62fpz4lh0rz531ajo2t5ef.gz OpenCV-4.5.0-aarch64.tar.gz
-      args:
-        chdir: "{{ source_build_dir }}/jetson-containers/scripts"
-      become: true
-  vars:
-    block_name: OpenCV
-  when: not opencv_build_dir_exist.stat.exists
+# - name: Build and install OpenCV
+#   block:
+#     - name: "{{ block_name }}: Download install script"
+#       ansible.builtin.git:
+#         repo: https://github.com/dusty-nv/jetson-containers.git
+#         dest: "{{ source_build_dir }}/jetson-containers"
+#         version: L4T-R35.1.0
+#     - name: "{{ block_name }}: install dependencies"
+#       shell: ./opencv_install_deps.sh
+#       args:
+#         chdir: "{{ source_build_dir }}/jetson-containers/scripts"
+#       become: true
+#     - name: "{{ block_name }}: execute install script"
+#       shell: ./opencv_install.sh https://nvidia.box.com/shared/static/5v89u6g5rb62fpz4lh0rz531ajo2t5ef.gz OpenCV-4.5.0-aarch64.tar.gz
+#       args:
+#         chdir: "{{ source_build_dir }}/jetson-containers/scripts"
+#       become: true
+#   vars:
+#     block_name: OpenCV
+#   when: not opencv_build_dir_exist.stat.exists
 
 - name: Check YAML build directory existence
   ansible.builtin.stat:
@@ -261,34 +266,34 @@
     block_name: YAML
   when: not yaml_cpp_build_dir_exist.stat.exists
 
-- name: Upgrade CMake
-  block:
-    - name: "{{ block_name }}: update gpg key"
-      shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-    # Follow drirections here: https://apt.kitware.com/
-    - name: "{{ block_name }}: update repository info"
-      ansible.builtin.apt_repository:
-        repo: deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ {{ ansible_distribution_release }} main
-        filename: kitware
-    - name: "{{ block_name }}: apt update"
-      ansible.builtin.apt:
-        update_cache: true
-        state: present
+# - name: Upgrade CMake
+#   block:
+    # - name: "{{ block_name }}: update gpg key"
+    #   shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    # # Follow drirections here: https://apt.kitware.com/
+    # - name: "{{ block_name }}: update repository info"
+    #   ansible.builtin.apt_repository:
+    #     repo: deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ {{ ansible_distribution_release }} main
+    #     filename: kitware
+    # - name: "{{ block_name }}: apt update"
+    #   ansible.builtin.apt:
+    #     update_cache: true
+    #     state: present
     # - name: "{{ block_name }}: delete gpg key"
     #   ansible.builtin.file:
     #     path: /usr/share/keyrings/kitware-archive-keyring.gpg
     #     state: absent
-    - name: "{{ block_name }}: install kitware-arcyhive-keyring"
-      ansible.builtin.apt:
-        name: kitware-archive-keyring
-    - name: "{{ block_name }}: install newer cmake"
-      ansible.builtin.apt:
-        name: cmake
-        install_recommends: false
-        state: latest
-  become: true
-  vars:
-    block_name: Upgrade CMake
+    # - name: "{{ block_name }}: install kitware-arcyhive-keyring"
+    #   ansible.builtin.apt:
+    #     name: kitware-archive-keyring
+    # - name: "{{ block_name }}: install newer cmake"
+    #   ansible.builtin.apt:
+    #     name: cmake
+    #     install_recommends: false
+    #     state: latest
+  # become: true
+  # vars:
+  #   block_name: Upgrade CMake
 
 - name: update GCC
   block:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -17,13 +17,13 @@
           - apt-transport-https
         install_recommends: false
         update_cache: true
-    # - name: Add ROS 2 source list
-    #   shell: echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-    # - name: Download gpg key
-    #   ansible.builtin.uri:
-    #     url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
-    #     dest: /usr/share/keyrings/ros-archive-keyring.gpg
-    #     follow_redirects: all
+    - name: Add ROS 2 source list
+      shell: echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+    - name: Download gpg key
+      ansible.builtin.uri:
+        url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
+        dest: /usr/share/keyrings/ros-archive-keyring.gpg
+        follow_redirects: all
     - name: Apt install
       ansible.builtin.apt:
         name:
@@ -266,34 +266,34 @@
     block_name: YAML
   when: not yaml_cpp_build_dir_exist.stat.exists
 
-# - name: Upgrade CMake
-#   block:
-    # - name: "{{ block_name }}: update gpg key"
-    #   shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-    # # Follow drirections here: https://apt.kitware.com/
-    # - name: "{{ block_name }}: update repository info"
-    #   ansible.builtin.apt_repository:
-    #     repo: deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ {{ ansible_distribution_release }} main
-    #     filename: kitware
-    # - name: "{{ block_name }}: apt update"
-    #   ansible.builtin.apt:
-    #     update_cache: true
-    #     state: present
-    # - name: "{{ block_name }}: delete gpg key"
-    #   ansible.builtin.file:
-    #     path: /usr/share/keyrings/kitware-archive-keyring.gpg
-    #     state: absent
-    # - name: "{{ block_name }}: install kitware-arcyhive-keyring"
-    #   ansible.builtin.apt:
-    #     name: kitware-archive-keyring
-    # - name: "{{ block_name }}: install newer cmake"
-    #   ansible.builtin.apt:
-    #     name: cmake
-    #     install_recommends: false
-    #     state: latest
-  # become: true
-  # vars:
-  #   block_name: Upgrade CMake
+- name: Upgrade CMake
+  block:
+    # Follow drirections here: https://apt.kitware.com/
+    - name: "{{ block_name }}: update repository info"
+      ansible.builtin.apt_repository:
+        repo: deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ {{ ansible_distribution_release }} main
+        filename: kitware
+    - name: "{{ block_name }}: delete gpg key"
+      ansible.builtin.file:
+        path: /usr/share/keyrings/kitware-archive-keyring.gpg
+        state: absent
+    - name: "{{ block_name }}: update gpg key"
+      shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    - name: "{{ block_name }}: apt update"
+      ansible.builtin.apt:
+        update_cache: true
+        state: present
+    - name: "{{ block_name }}: install kitware-archive-keyring"
+      ansible.builtin.apt:
+        name: kitware-archive-keyring
+    - name: "{{ block_name }}: install newer cmake"
+      ansible.builtin.apt:
+        name: cmake
+        install_recommends: false
+        state: latest
+  become: true
+  vars:
+    block_name: Upgrade CMake
 
 - name: update GCC
   block:

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -35,15 +35,11 @@
           - libbullet-dev
           - libpython3-dev
           - python3-wheel
-          # - python3-colcon-common-extensions
           - python3-flake8
           - python3-pip
           - python3-numpy
-          - python3-pytest-cov
-          # - python3-rosdep
+          - python3-pytest-covdep
           - python3-setuptools
-          # - python3-vcstool
-          # - python3-rosinstall-generator
           - libasio-dev
           - libtinyxml2-dev
           - libcunit1-dev
@@ -214,27 +210,6 @@
     path: "{{ source_build_dir }}/jetson-containers"
   register: opencv_build_dir_exist
 
-# - name: Build and install OpenCV
-#   block:
-#     - name: "{{ block_name }}: Download install script"
-#       ansible.builtin.git:
-#         repo: https://github.com/dusty-nv/jetson-containers.git
-#         dest: "{{ source_build_dir }}/jetson-containers"
-#         version: L4T-R35.1.0
-#     - name: "{{ block_name }}: install dependencies"
-#       shell: ./opencv_install_deps.sh
-#       args:
-#         chdir: "{{ source_build_dir }}/jetson-containers/scripts"
-#       become: true
-#     - name: "{{ block_name }}: execute install script"
-#       shell: ./opencv_install.sh https://nvidia.box.com/shared/static/5v89u6g5rb62fpz4lh0rz531ajo2t5ef.gz OpenCV-4.5.0-aarch64.tar.gz
-#       args:
-#         chdir: "{{ source_build_dir }}/jetson-containers/scripts"
-#       become: true
-#   vars:
-#     block_name: OpenCV
-#   when: not opencv_build_dir_exist.stat.exists
-
 - name: Check YAML build directory existence
   ansible.builtin.stat:
     path: "{{ source_build_dir }}/yaml-cpp"
@@ -268,7 +243,7 @@
 
 - name: Upgrade CMake
   block:
-    # Follow drirections here: https://apt.kitware.com/
+    # Follow directions here: https://apt.kitware.com/
     - name: "{{ block_name }}: update gpg key"
       shell: wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
     - name: "{{ block_name }}: update repository info"

--- a/ansible/roles/tier4_hdr_camera_driver/defaults/main.yaml
+++ b/ansible/roles/tier4_hdr_camera_driver/defaults/main.yaml
@@ -1,3 +1,3 @@
-camera_driver_repo: https://api.github.com/repos/tier4/tier4_automotive_hdr_camera/releases/latest
+camera_driver_repo: https://api.github.com/repos/tier4/tier4_automotive_hdr_camera/releases/142093397
 camera_driver_download_dir: /tmp
 exposure_time: 11000

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -19,6 +19,7 @@
         [Warning] Do you want to configure the network? This configuration may overwrite the IP address of the specific network interface [y/N]
       private: false
   roles:
+    - role: artifacts
     - role: autoware
     - role: cuda
     - role: cyclonedds

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -28,10 +28,10 @@
     - role: calibration_tools
     - role: tier4_hdr_camera_driver
       when: prompt_install_camera_driver == 'y'
+    - role: ros2
     - role: ptp4l_client
       when: prompt_configure_network == 'y'
     - role: enlarge_txqueue
       when: prompt_configure_network == 'y'
     - role: netplan
       when: prompt_configure_network == 'y'
-    - role: ros2

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -27,10 +27,10 @@
     - role: calibration_tools
     - role: tier4_hdr_camera_driver
       when: prompt_install_camera_driver == 'y'
-    - role: ros2
     - role: ptp4l_client
       when: prompt_configure_network == 'y'
     - role: enlarge_txqueue
       when: prompt_configure_network == 'y'
     - role: netplan
       when: prompt_configure_network == 'y'
+    - role: ros2

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -20,6 +20,12 @@
       private: false
   roles:
     - role: artifacts
+    - role: ptp4l_client
+      when: prompt_configure_network == 'y'
+    - role: enlarge_txqueue
+      when: prompt_configure_network == 'y'
+    - role: netplan
+      when: prompt_configure_network == 'y'
     - role: autoware
     - role: cuda
     - role: cyclonedds
@@ -29,9 +35,3 @@
     - role: tier4_hdr_camera_driver
       when: prompt_install_camera_driver == 'y'
     - role: ros2
-    - role: ptp4l_client
-      when: prompt_configure_network == 'y'
-    - role: enlarge_txqueue
-      when: prompt_configure_network == 'y'
-    - role: netplan
-      when: prompt_configure_network == 'y'

--- a/autoware.repos
+++ b/autoware.repos
@@ -58,3 +58,11 @@ repositories:
     type: git
     url: https://github.com/tier4/tensorrt_cmake_module.git
     version: main
+  demos:
+    type: git
+    url: https://github.com/ros2/demos.git
+    version: humble
+  autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: main

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -49,7 +49,7 @@ export PATH="$HOME/.local/bin:$PATH"
 echo -e "\e[36mRunning ansible playbook to setup ECU.\e[0m"
 
 # Run ansible
-if ansible-playbook "${SCRIPT_DIR}"/ansible/setup.yaml --ask-become-pass; then
+if ansible-playbook "${SCRIPT_DIR}"/ansible/setup.yaml --ask-become-pass --extra-vars data_dir=$HOME/autoware_data; then
     echo -e "\e[32mCompleted.\e[0m"
     exit 0
 else

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -49,7 +49,7 @@ export PATH="$HOME/.local/bin:$PATH"
 echo -e "\e[36mRunning ansible playbook to setup ECU.\e[0m"
 
 # Run ansible
-if ansible-playbook "${SCRIPT_DIR}"/ansible/setup.yaml --ask-become-pass --extra-vars data_dir=$HOME/autoware_data; then
+if ansible-playbook "${SCRIPT_DIR}"/ansible/setup.yaml --ask-become-pass --extra-vars data_dir="$HOME"/autoware_data; then
     echo -e "\e[32mCompleted.\e[0m"
     exit 0
 else


### PR DESCRIPTION
- Added a task to check if the GitHub API return is valid
- Added a task to ensure driver_deb_download_url is defined
- Added tasks to extract and fix the driver tar.gz file
- Added a task to run the installation script
- Removed the task to install the driver from deb file
- Removed the task to install the SDK from deb file
- Updated the task to setup camera driver and SDK
- Added an ansible task to download install missing object detection model
- Updates the object detection launcher to use the models downloaded in the previous step.

Verified using the following command, after a successful installation with ansible and a restart to allow the camera driver to load.
`ros2 launch edge_auto_jetson_launch edge_auto_jetson.launch.xml`
