### PR TITLE
Fix dependency name problem edge-auto-jetson architecture

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -38,7 +38,7 @@
           - python3-flake8
           - python3-pip
           - python3-numpy
-          - python3-pytest-covdep
+          - python3-pytest-cov
           - python3-setuptools
           - libasio-dev
           - libtinyxml2-dev


### PR DESCRIPTION
## Description
It seems that there is a problem with the dependency name: python3-pytest-covdep, just rename it to python3-pytest-cov and that solves the problem running the script ./setup-dev-env.sh

<!-- Write a brief description of this PR. -->

## Tests performed
Verified that this problem is fixed executing the script twice in a fresh image
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
