### PR TITLE
fix: error during colcon build

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -75,6 +75,7 @@
       - vcstool
       - colcon-common-extensions
       - rosinstall-generator
+      - empy==3.3.4
     extra_args: -U
   become: true # need to sudo privilege to install packages globally
 


### PR DESCRIPTION
fix AttributeError: module 'em' has no attribute 'BUFFERED_OPT' during colcon build

refer this https://github.com/carla-simulator/ros-bridge/issues/712
