### PR TITLE
fix: add replacement process on ansible role to avoid fix fastrtps build ...

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -319,6 +319,9 @@
         src: /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
         dest: "{{ ros_base_dir }}/ros2.{{ ros_distro }}.ros_base.rosinstall"
       become: true
+    - name: "{{ block_name }}: fix fastrtsp version"
+      shell: sed -i "s/release\/humble\/fastrtps\/2.6.9-1/release\/humble\/fastrtps\/2.6.8-1/" {{ ros_base_dir }}/ros2.{{ ros_distro }}.ros_base.rosinstall
+      become: true
     - name: "{{ block_name }}: clone all repositories via vcs"
       shell: vcs import src < ros2.{{ ros_distro }}.ros_base.rosinstall
       args:


### PR DESCRIPTION
When building ros `fastrtps` package, the build error occured. 

This is because the class structure was changed in the [update of ros `fastrps`](https://github.com/ros2-gbp/fastrtps-release?tab=readme-ov-file#fastrtps-humble---269-1)

So, specified version of fastrps source on `rosinstall` file.