### PR TITLE
fix: update download link for boost v1.74.0

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -98,7 +98,7 @@
   block:
     - name: "{{ block_name }}: Download and extract source"
       ansible.builtin.unarchive:
-        src: https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+        src: https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.gz
         dest: "{{ source_build_dir }}"
         remote_src: true
     - name: "{{ block_name }}: Build boost"

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -98,7 +98,7 @@
   block:
     - name: "{{ block_name }}: Download and extract source"
       ansible.builtin.unarchive:
-        src: https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz
+        src: https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
         dest: "{{ source_build_dir }}"
         remote_src: true
     - name: "{{ block_name }}: Build boost"


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

As you see in https://github.com/boostorg/boost/issues/997, https://boostorg.jfrog.io is out of service. So I updated the link.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I did NOT check this PR by running ansible.
@softyanija , @TetsuKawa , @Owen-Liuyuxuan,  can you check this PR by running ansible?

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

This PR may affect the environment, especially related to boost.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
