### PR TITLE
fix: run service after network-online

### DIFF
--- a/ansible/roles/perception_application/templates/perception-startup.service.j2
+++ b/ansible/roles/perception_application/templates/perception-startup.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=perception launch
-After=network.target
-Requires=network.target
+After=network-online.target
+Requires=network-online.target
 
 # cspell: ignore pkill
 # cspell: ignore RTPRIO


### PR DESCRIPTION
## Description
The systemd service for the perception application runs after `network.target`, but this doesn't ensure that the network port is ready, causing CycloneDDS to fail with the following errors.
I changed it to `network-online.target` to ensure the service runs after the network port is ready.

```
Apr 28 10:21:35 addon systemd[1]: Started perception launch.
Apr 28 10:21:36 addon run.sh[1004]: [INFO] [launch]: All log files can be found below root/.ros/log/2025-04-28-10-21-36-621066-addon-1004
Apr 28 10:21:36 addon run.sh[1004]: [INFO] [launch]: Default logging verbosity is set to INFO
Apr 28 10:21:36 addon run.sh[1004]: 1745803296.834784 [1]       ros2: enp7s0: does not match an available interface.
Apr 28 10:21:36 addon run.sh[1004]: [ERROR 1745803296.834809698] [rmw_cyclonedds_cpp] check_create_domain(): "rmw_create_node: failed to create domain, error Error" at (.>
Apr 28 10:21:36 addon run.sh[1004]: >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
Apr 28 10:21:36 addon run.sh[1004]: This error state is being overwritten:
Apr 28 10:21:36 addon run.sh[1004]:   'error not set, at ./src/rcl/node.c:263'
Apr 28 10:21:36 addon run.sh[1004]: with this new error message:
Apr 28 10:21:36 addon run.sh[1004]:   'rcl node's rmw handle is invalid, at ./src/rcl/node.c:415'
Apr 28 10:21:36 addon run.sh[1004]: rcutils_reset_error() should be called after error handling to avoid this.
Apr 28 10:21:36 addon run.sh[1004]: <<<
Apr 28 10:21:36 addon run.sh[1004]: [ERROR 1745803296.834828236] [rcl] rcl_node_init(): "Failed to fini publisher for node: 1" at (./src/rcl/node.c:L312)
Apr 28 10:21:36 addon run.sh[1004]: [ERROR] [launch]: Caught exception in launch (see debug for traceback): error creating node: rcl node's rmw handle is invalid, at ./sr>
Apr 28 10:21:36 addon systemd[1]: perception-startup.service: Main process exited, code=exited, status=1/FAILURE
Apr 28 10:21:36 addon systemd[1]: perception-startup.service: Failed with result 'exit-code'.
Apr 28 10:21:36 addon systemd[1]: perception-startup.service: Consumed 1.024s CPU time.
Apr 28 10:21:37 addon systemd[1]: perception-startup.service: Scheduled restart job, restart counter is at 1.
Apr 28 10:21:37 addon systemd[1]: Stopped perception launch.
Apr 28 10:21:37 addon systemd[1]: perception-startup.service: Consumed 1.024s CPU time.
Apr 28 10:21:37 addon systemd[1]: Started perception launch.
Apr 28 10:21:37 addon run.sh[1393]: [INFO] [launch]: All log files can be found below root/.ros/log/2025-04-28-10-21-37-526056-addon-1393
Apr 28 10:21:37 addon run.sh[1393]: [INFO] [launch]: Default logging verbosity is set to INFO
Apr 28 10:21:37 addon run.sh[1393]: 1745803297.634813 [1]       ros2: enp7s0: does not match an available interface.
Apr 28 10:21:37 addon run.sh[1393]: [ERROR 1745803297.634842696] [rmw_cyclonedds_cpp] check_create_domain(): "rmw_create_node: failed to create domain, error Error" at (.>
Apr 28 10:21:37 addon run.sh[1393]: >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
Apr 28 10:21:37 addon run.sh[1393]: This error state is being overwritten:
Apr 28 10:21:37 addon run.sh[1393]:   'error not set, at ./src/rcl/node.c:263'
Apr 28 10:21:37 addon run.sh[1393]: with this new error message:
Apr 28 10:21:37 addon run.sh[1393]:   'rcl node's rmw handle is invalid, at ./src/rcl/node.c:415'
Apr 28 10:21:37 addon run.sh[1393]: rcutils_reset_error() should be called after error handling to avoid this.
Apr 28 10:21:37 addon run.sh[1393]: <<<
Apr 28 10:21:37 addon run.sh[1393]: [ERROR 1745803297.634861524] [rcl] rcl_node_init(): "Failed to fini publisher for node: 1" at (./src/rcl/node.c:L312)
Apr 28 10:21:37 addon run.sh[1393]: [ERROR] [launch]: Caught exception in launch (see debug for traceback): error creating node: rcl node's rmw handle is invalid, at ./sr>
Apr 28 10:21:37 addon systemd[1]: perception-startup.service: Main process exited, code=exited, status=1/FAILURE
Apr 28 10:21:37 addon systemd[1]: perception-startup.service: Failed with result 'exit-code'.
Apr 28 10:21:37 addon systemd[1]: perception-startup.service: Scheduled restart job, restart counter is at 2.
Apr 28 10:21:37 addon systemd[1]: Stopped perception launch.
Apr 28 10:21:37 addon systemd[1]: Started perception launch.
Apr 28 10:21:38 addon run.sh[1600]: [INFO] [launch]: All log files can be found below root/.ros/log/2025-04-28-10-21-38-353544-addon-1600
Apr 28 10:21:38 addon run.sh[1600]: [INFO] [launch]: Default logging verbosity is set to INFO
Apr 28 10:21:38 addon run.sh[1600]: 1745803298.465386 [1]       ros2: enp7s0: does not match an available interface.
Apr 28 10:21:38 addon run.sh[1600]: [ERROR 1745803298.465418164] [rmw_cyclonedds_cpp] check_create_domain(): "rmw_create_node: failed to create domain, error Error" at (.>
Apr 28 10:21:38 addon run.sh[1600]: >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
Apr 28 10:21:38 addon run.sh[1600]: This error state is being overwritten:
Apr 28 10:21:38 addon run.sh[1600]:   'error not set, at ./src/rcl/node.c:263'
Apr 28 10:21:38 addon run.sh[1600]: with this new error message:
Apr 28 10:21:38 addon run.sh[1600]:   'rcl node's rmw handle is invalid, at ./src/rcl/node.c:415'
Apr 28 10:21:38 addon run.sh[1600]: rcutils_reset_error() should be called after error handling to avoid this.
Apr 28 10:21:38 addon run.sh[1600]: <<<
Apr 28 10:21:38 addon run.sh[1600]: [ERROR 1745803298.465437882] [rcl] rcl_node_init(): "Failed to fini publisher for node: 1" at (./src/rcl/node.c:L312)
Apr 28 10:21:38 addon run.sh[1600]: [ERROR] [launch]: Caught exception in launch (see debug for traceback): error creating node: rcl node's rmw handle is invalid, at ./sr>
Apr 28 10:21:38 addon systemd[1]: perception-startup.service: Main process exited, code=exited, status=1/FAILURE
Apr 28 10:21:38 addon systemd[1]: perception-startup.service: Failed with result 'exit-code'.
Apr 28 10:21:38 addon systemd[1]: perception-startup.service: Scheduled restart job, restart counter is at 3.
Apr 28 10:21:38 addon systemd[1]: Stopped perception launch.
Apr 28 10:21:38 addon systemd[1]: Started perception launch.
Apr 28 10:21:39 addon run.sh[2050]: [INFO] [launch]: All log files can be found below root/.ros/log/2025-04-28-10-21-39-151626-addon-2050
Apr 28 10:21:39 addon run.sh[2050]: [INFO] [launch]: Default logging verbosity is set to INFO
Apr 28 10:21:39 addon run.sh[2050]: 1745803299.259724 [1]       ros2: enp7s0: does not match an available interface.
Apr 28 10:21:39 addon run.sh[2050]: [ERROR 1745803299.259750344] [rmw_cyclonedds_cpp] check_create_domain(): "rmw_create_node: failed to create domain, error Error" at (.>
Apr 28 10:21:39 addon run.sh[2050]: >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
Apr 28 10:21:39 addon run.sh[2050]: This error state is being overwritten:
Apr 28 10:21:39 addon run.sh[2050]:   'error not set, at ./src/rcl/node.c:263'
Apr 28 10:21:39 addon run.sh[2050]: with this new error message:
Apr 28 10:21:39 addon run.sh[2050]:   'rcl node's rmw handle is invalid, at ./src/rcl/node.c:415'
Apr 28 10:21:39 addon run.sh[2050]: rcutils_reset_error() should be called after error handling to avoid this.
Apr 28 10:21:39 addon run.sh[2050]: <<<
Apr 28 10:21:39 addon run.sh[2050]: [ERROR 1745803299.259768773] [rcl] rcl_node_init(): "Failed to fini publisher for node: 1" at (./src/rcl/node.c:L312)
Apr 28 10:21:39 addon run.sh[2050]: [ERROR] [launch]: Caught exception in launch (see debug for traceback): error creating node: rcl node's rmw handle is invalid, at ./sr>
Apr 28 10:21:39 addon systemd[1]: perception-startup.service: Main process exited, code=exited, status=1/FAILURE
Apr 28 10:21:39 addon systemd[1]: perception-startup.service: Failed with result 'exit-code'.
Apr 28 10:21:39 addon systemd[1]: perception-startup.service: Scheduled restart job, restart counter is at 4.
Apr 28 10:21:39 addon systemd[1]: Stopped perception launch.
Apr 28 10:21:39 addon systemd[1]: Started perception launch.
Apr 28 10:21:40 addon run.sh[2180]: [INFO] [launch]: All log files can be found below root/.ros/log/2025-04-28-10-21-40-013338-addon-2180
Apr 28 10:21:40 addon run.sh[2180]: [INFO] [launch]: Default logging verbosity is set to INFO
Apr 28 10:21:40 addon run.sh[2180]: 1745803300.118883 [1]       ros2: enp7s0: does not match an available interface.
Apr 28 10:21:40 addon run.sh[2180]: [ERROR 1745803300.118913517] [rmw_cyclonedds_cpp] check_create_domain(): "rmw_create_node: failed to create domain, error Error" at (.>
Apr 28 10:21:40 addon run.sh[2180]: >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
Apr 28 10:21:40 addon run.sh[2180]: This error state is being overwritten:
Apr 28 10:21:40 addon run.sh[2180]:   'error not set, at ./src/rcl/node.c:263'
Apr 28 10:21:40 addon run.sh[2180]: with this new error message:
Apr 28 10:21:40 addon run.sh[2180]:   'rcl node's rmw handle is invalid, at ./src/rcl/node.c:415'
Apr 28 10:21:40 addon run.sh[2180]: rcutils_reset_error() should be called after error handling to avoid this.
Apr 28 10:21:40 addon run.sh[2180]: <<<
Apr 28 10:21:40 addon run.sh[2180]: [ERROR 1745803300.118930457] [rcl] rcl_node_init(): "Failed to fini publisher for node: 1" at (./src/rcl/node.c:L312)
Apr 28 10:21:40 addon run.sh[2180]: [ERROR] [launch]: Caught exception in launch (see debug for traceback): error creating node: rcl node's rmw handle is invalid, at ./sr>
Apr 28 10:21:40 addon systemd[1]: perception-startup.service: Main process exited, code=exited, status=1/FAILURE
Apr 28 10:21:40 addon systemd[1]: perception-startup.service: Failed with result 'exit-code'.
Apr 28 10:21:40 addon systemd[1]: perception-startup.service: Scheduled restart job, restart counter is at 5.
Apr 28 10:21:40 addon systemd[1]: Stopped perception launch.
Apr 28 10:21:40 addon systemd[1]: perception-startup.service: Start request repeated too quickly.
Apr 28 10:21:40 addon systemd[1]: perception-startup.service: Failed with result 'exit-code'.
Apr 28 10:21:40 addon systemd[1]: Failed to start perception launch.
-- Boot 6576ad9446dc4c3f977d38cde5486fc6 --
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed the service launched successfully on the bench.
```
autoware@addon:~$ cat /etc/systemd/system/perception-startup.service 
[Unit]
Description=perception launch
After=network-online.target
Requires=network-online.target

# cspell: ignore pkill
# cspell: ignore RTPRIO
[Service]
TimeoutStartSec=0
Restart=always
ExecStart=/opt/autoware/perception-startup-service/run.sh
ExecStop=/usr/bin/pkill -f edge_auto_jetson_launch && /usr/bin/pkill -f jetson_addon_launch
KillMode=control-group
KillSignal=SIGQUIT
LimitRTPRIO=98
# https://answers.ros.org/question/367935/systemd-does-not-work-with-ros2/
# Set environment to make ros2 command available in run.sh
Environment="HOME=root"

[Install]
WantedBy=multi-user.target
```

```
Apr 30 07:58:26 addon systemd[1]: Started perception launch.
Apr 30 07:58:28 addon run.sh[1971]: [INFO] [launch]: All log files can be found below root/.ros/log/2025-04-30-07-58-28-020733-addon-1971
Apr 30 07:58:28 addon run.sh[1971]: [INFO] [launch]: Default logging verbosity is set to INFO
Apr 30 07:58:28 addon run.sh[1971]: [INFO] [component_container_mt-1]: process started with pid [2124]
Apr 30 07:58:28 addon run.sh[1971]: [INFO] [component_container_mt-2]: process started with pid [2126]
Apr 30 07:58:28 addon run.sh[1971]: [INFO] [component_container_mt-3]: process started with pid [2128]
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-1] [INFO 1745967508.433758986] [object_recognition_container8] create_component_factory(): "Load Library: /home/autoware/overlay_ws/install/autoware_tensorrt_yolox>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-2] [INFO 1745967508.469730868] [object_recognition_container9] create_component_factory(): "Load Library: /home/autoware/overlay_ws/install/autoware_tensorrt_yolox>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-3] [INFO 1745967508.509844223] [object_recognition_container10] create_component_factory(): "Load Library: /home/autoware/overlay_ws/install/autoware_tensorrt_yolo>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-3] [INFO 1745967508.887542058] [object_recognition_container10] create_component_factory(): "Found class: rclcpp_components::NodeFactoryTemplate<autoware::tensorrt>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-3] [INFO 1745967508.887634841] [object_recognition_container10] create_component_factory(): "Instantiate class: rclcpp_components::NodeFactoryTemplate<autoware::te>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-1] [INFO 1745967508.887542001] [object_recognition_container8] create_component_factory(): "Found class: rclcpp_components::NodeFactoryTemplate<autoware::tensorrt_>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-1] [INFO 1745967508.887634826] [object_recognition_container8] create_component_factory(): "Instantiate class: rclcpp_components::NodeFactoryTemplate<autoware::ten>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-2] [INFO 1745967508.887542022] [object_recognition_container9] create_component_factory(): "Found class: rclcpp_components::NodeFactoryTemplate<autoware::tensorrt_>
Apr 30 07:58:28 addon run.sh[1971]: [component_container_mt-2] [INFO 1745967508.887634910] [object_recognition_container9] create_component_factory(): "Instantiate class: rclcpp_components::NodeFactoryTemplate<autoware::ten>
Apr 30 07:58:29 addon run.sh[1971]: [component_container_mt-2] [I] [TRT] [MemUsageChange] Init CUDA: CPU +2, GPU +0, now: CPU 33, GPU 1380 (MiB)
Apr 30 07:58:29 addon run.sh[1971]: [component_container_mt-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +2, GPU +0, now: CPU 33, GPU 1418 (MiB)
Apr 30 07:58:29 addon run.sh[1971]: [component_container_mt-3] [I] [TRT] [MemUsageChange] Init CUDA: CPU +2, GPU +0, now: CPU 33, GPU 1606 (MiB)
Apr 30 07:58:35 addon run.sh[1971]: [component_container_mt-1] [I] [TRT] [MemUsageChange] Init builder kernel library: CPU +1453, GPU +988, now: CPU 1565, GPU 2820 (MiB)

...
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
