### PR TITLE
fix: using new ros2 install method

### DIFF
--- a/ansible/base_edge.yaml
+++ b/ansible/base_edge.yaml
@@ -2,5 +2,4 @@
   hosts: localhost
 
   roles:
-    - { role: cuda }
     - { role: ros2 }

--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -5,6 +5,7 @@ This role installs [ROS 2](http://www.ros2.org/) on Ubuntu systems following the
 ## Overview
 
 This role performs a complete ROS 2 installation including:
+
 - Setting up ROS 2 repositories and GPG keys
 - Installing core ROS 2 packages based on the specified distribution
 - Installing development dependencies and tools
@@ -26,6 +27,7 @@ The default `installation_type` can be found in:
 ## Features
 
 This role:
+
 - Authorizes the ROS GPG key
 - Configures the appropriate ROS 2 apt repository
 - Installs basic system dependencies
@@ -40,6 +42,7 @@ This role:
 ## Additional Packages
 
 The role installs numerous additional ROS 2 packages beyond the base installation, including:
+
 - Launch tools (XML, YAML, testing)
 - Demo nodes
 - Computer vision packages

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -92,6 +92,37 @@
       - flake8-quotes
     extra_args: --upgrade --no-cache-dir
 
+- name: Check if NVIDIA L4T source file exists
+  ansible.builtin.stat:
+    path: /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+  register: nvidia_l4t_source
+
+- name: Backup NVIDIA L4T apt source file
+  become: true
+  ansible.builtin.command: mv /etc/apt/sources.list.d/nvidia-l4t-apt-source.list /etc/apt/sources.list.d/nvidia-l4t-apt-source.list.bak
+  when: nvidia_l4t_source.stat.exists
+  register: nvidia_source_backup
+
+- name: Update apt cache after backup
+  become: true
+  ansible.builtin.apt:
+    update_cache: yes
+  when: nvidia_source_backup.changed
+
+- name: Remove all OpenCV packages
+  become: true
+  ansible.builtin.apt:
+    name: "*opencv*"
+    state: absent
+    purge: yes
+  register: opencv_removed
+
+- name: Update apt cache after OpenCV removal
+  become: true
+  ansible.builtin.apt:
+    update_cache: yes
+  when: opencv_removed.changed
+
 - name: Install ROS2 {{ ros_distro }}
   become: true
   ansible.builtin.apt:
@@ -163,3 +194,17 @@
 - name: Update rosdep
   ansible.builtin.command: rosdep update
   changed_when: false
+
+- name: Restore NVIDIA L4T apt source file
+  become: true
+  ansible.builtin.command: mv /etc/apt/sources.list.d/nvidia-l4t-apt-source.list.bak /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+  args:
+    removes: /etc/apt/sources.list.d/nvidia-l4t-apt-source.list.bak
+  when: nvidia_source_backup.changed
+  register: nvidia_source_restore
+
+- name: Update apt cache after restoring NVIDIA sources
+  become: true
+  ansible.builtin.apt:
+    update_cache: yes
+  when: nvidia_source_restore.changed

--- a/ansible/roles/tier4_hdr_camera_driver/README.md
+++ b/ansible/roles/tier4_hdr_camera_driver/README.md
@@ -35,6 +35,7 @@ This role performs the following steps:
 ## Boot-time Installation
 
 The driver installation is completed at boot time because:
+
 - Kernel module compilation needs to match the running kernel
 - This approach ensures the driver is properly rebuilt after kernel updates
 - It prevents installation failures during the Ansible deployment phase
@@ -60,16 +61,19 @@ Include this role in your playbook:
 If the camera driver fails to load after installation:
 
 1. Check the systemd service status:
+
    ```
    sudo systemctl status camera-driver-installer
    ```
 
 2. Review the installation logs:
+
    ```
    sudo journalctl -u camera-driver-installer
    ```
 
 3. Verify the driver is properly installed:
+
    ```
    dpkg -l | grep tier4-camera-gmsl
    ```


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
We removed CUDA role during building base image processing.
And remove opencv 4.8 before install ROS2. Because during ROS2 install, opencv 4.5 will be automatically installed.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
