### PR TITLE
chore: use new way to add ros2 apt source

### DIFF
--- a/.github/workflows/create-base-anvil-image.yaml
+++ b/.github/workflows/create-base-anvil-image.yaml
@@ -66,13 +66,6 @@ jobs:
           echo "tag-name-with-suffix=$VERSION_WITH_SUFFIX" >> $GITHUB_OUTPUT
           echo "has-suffix=$([[ -n "$TAG_SUFFIX" ]] && echo "true" || echo "false")" >> $GITHUB_OUTPUT
 
-      - name: Check ROS 2 Package Versions
-        run: |
-          sudo apt update && sudo apt install curl gnupg lsb-release
-          sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-          sudo apt update
-          echo "ROS_DESKTOP_VER=$( apt-cache madison ros-${ROS_DISTRO}-desktop | cut -d \| -f 2 | cut -c 2- )" >> $GITHUB_ENV
       - name: set description
         id: set-description
         run: |


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Same as https://github.com/tier4/edge-auto-jetson/pull/84

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
- Create image https://github.com/tier4/edge-auto-jetson/pkgs/container/edge-auto-jetson%2Frqx-580-base-image/versions?filters%5Bversion_type%5D=tagged
- corresponding pilot-auto.xx1 https://github.com/tier4/pilot-auto.xx1/commit/67bfe487ba63f0b327cc0a9288537345b3ca1e31
- Evaluator pass https://evaluation.tier4.jp/evaluation/reports/c29c8516-19aa-542b-a2cd-177530423fe6?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
