### PR TITLE
Beta/anvil/v0.48.0 update cgroup

### DIFF
--- a/ansible/roles/cgroups/tasks/main.yaml
+++ b/ansible/roles/cgroups/tasks/main.yaml
@@ -11,3 +11,38 @@
     dest: /etc/systemd/system/user@.service.d/user-resources.conf
     mode: 0755
   become: true
+
+- name: Install dependent package to set SYS_CAP
+  ansible.builtin.apt:
+    name: libcap2-bin
+    update_cache: true
+  become: true
+
+- name: Find the actual executable path
+  ansible.builtin.find:
+    paths: "{{ cgroup.executable_find_path }}"
+    patterns: "{{ cgroup.executable_name }}"
+    file_type: any
+    recurse: true
+  register: executable_find_output_raw
+
+- name: Determine the actual path of the executable to adapt to the case of symlink-install
+  ansible.builtin.command:
+    cmd: "readlink -f {{ item.path }}"
+  with_items: "{{ executable_find_output_raw.files }}"
+  register: executable_find_output
+
+- name: Set cap_sys_nice+ep
+  community.general.capabilities:
+    path: "{{ item.stdout }}"
+    capability: cap_sys_nice+ep
+    state: present
+  with_items: "{{ executable_find_output.results }}" # assume this conteins only one element
+  become: true
+
+- name: Copy config to /etc/ld.so.conf.d so that ld can find libraries
+  ansible.builtin.template:
+    src: cgroup_executable.conf.jinja2
+    dest: "/etc/ld.so.conf.d/{{ cgroup.executable_name }}.conf"
+    mode: 0644
+  become: true

--- a/ansible/roles/cgroups/templates/cgroup_executable.conf.jinja2
+++ b/ansible/roles/cgroups/templates/cgroup_executable.conf.jinja2
@@ -1,0 +1,5 @@
+#jinja2: trim_blocks: False
+/opt/ros/humble/install/lib
+{%- for item in  executable_find_output.results %}
+{{ item.stdout | dirname }}
+{%- endfor %}

--- a/ansible/roles/cgroups/templates/cgroup_executable.conf.jinja2
+++ b/ansible/roles/cgroups/templates/cgroup_executable.conf.jinja2
@@ -1,5 +1,6 @@
 #jinja2: trim_blocks: False
-/opt/ros/humble/install/lib
+/opt/ros/humble/lib
+/opt/ros/humble/lib/aarch64-linux-gnu
 {%- for item in  executable_find_output.results %}
 {{ item.stdout | dirname }}
 {%- endfor %}


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR updates the cgroup configuration according to the BSP updates. 

Some programs, such as [sensor_trigger](https://github.com/tier4/sensor_trigger), require a higher priority for their thread so that it is prioritized for execution on their purpose, like keeping accurate timing control.

This modification makes it possible for such programs to promote their priority.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
After executing the `cgroups` role, execute 
```bash
ros2 run sensor_trigger sensor_trigger_exe   --ros-args --params-file <trigger.param.yaml>
```
Then, execute `htop` in another terminal, and check the value of `PR` for the `sensor_trigger_` has a negative value (such as `-31`). If the `cgroups` role is not applied, the `PR` value should positive value.

I also confirmed the validity of this PR using the bench environment; it revealed that the priority of the thread that sensor_trigger ran was `-31` and kept timing error (the difference between ideal timing and actual moment when trigger to be sent) under 1us even under the condition that all CPU cores are 100% occupied.
<img width="1917" height="1047" alt="Screenshot from 2025-08-15 23-11-40" src="https://github.com/user-attachments/assets/909b1656-7042-4bc9-a423-4d1f37a91db7" />


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
N/A

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Without this modification, the priority for the thread on which sensor_trigger runs does not get high, which leads to an inaccurate triggering period.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
