### PR TITLE
fix: make TIER IV camera setting configurable via ansible variables

### DIFF
--- a/ansible/roles/tier4_hdr_camera_driver/README.md
+++ b/ansible/roles/tier4_hdr_camera_driver/README.md
@@ -15,14 +15,11 @@ The TIER4 HDR Camera Driver provides support for GMSL (Gigabit Multimedia Serial
 ## Role Variables
 
 | Name                       | Required | Description                                                                                                                  |
-|----------------------------|----------|------------------------------------------------------------------------------------------------------------------------------|
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | camera_driver_repo         | yes      | URL to the GitHub API endpoint for the release assets                                                                        |
 | camera_driver_download_dir | yes      | Local directory where the driver package will be downloaded                                                                  |
 | exposure_time              | no       | Exposure length in microseconds to be set in the driver configuration file (default: `11000`)                                |
 | distortion_correction      | no       | Enable/disable the distortion correction function supported by the camera hardware (`1`: Enable, `0`: Disable. default: `0`) |
-
-
-
 
 ## Installation Process
 

--- a/ansible/roles/tier4_hdr_camera_driver/README.md
+++ b/ansible/roles/tier4_hdr_camera_driver/README.md
@@ -14,10 +14,15 @@ The TIER4 HDR Camera Driver provides support for GMSL (Gigabit Multimedia Serial
 
 ## Role Variables
 
-| Name                       | Required | Description                                                 |
-| -------------------------- | -------- | ----------------------------------------------------------- |
-| camera_driver_repo         | yes      | URL to the GitHub API endpoint for the release assets       |
-| camera_driver_download_dir | yes      | Local directory where the driver package will be downloaded |
+| Name                       | Required | Description                                                                                                                  |
+|----------------------------|----------|------------------------------------------------------------------------------------------------------------------------------|
+| camera_driver_repo         | yes      | URL to the GitHub API endpoint for the release assets                                                                        |
+| camera_driver_download_dir | yes      | Local directory where the driver package will be downloaded                                                                  |
+| exposure_time              | no       | Exposure length in microseconds to be set in the driver configuration file (default: `11000`)                                |
+| distortion_correction      | no       | Enable/disable the distortion correction function supported by the camera hardware (`1`: Enable, `0`: Disable. default: `0`) |
+
+
+
 
 ## Installation Process
 

--- a/ansible/roles/tier4_hdr_camera_driver/defaults/main.yaml
+++ b/ansible/roles/tier4_hdr_camera_driver/defaults/main.yaml
@@ -1,3 +1,4 @@
 camera_driver_repo: https://api.github.com/repos/tier4/tier4_automotive_hdr_camera/releases/latest
 camera_driver_download_dir: /tmp
 exposure_time: 11000
+distortion_correction: 0

--- a/ansible/roles/tier4_hdr_camera_driver/templates/camera-driver-installer.sh.j2
+++ b/ansible/roles/tier4_hdr_camera_driver/templates/camera-driver-installer.sh.j2
@@ -20,7 +20,7 @@ sed -i "s|root=/dev/mmcblk0p1|root=$(findmnt / -o SOURCE -n)|" "/boot/extlinux/e
 
 sed -i 's/^DEFAULT primary/DEFAULT t4_primary_c2x8/' /boot/extlinux/extlinux.conf
 
-sed -i 's/options tier4_imx490 trigger_mode=0 enable_auto_exposure=1 enable_distortion_correction=1/options tier4_imx490 trigger_mode=1 fsync_mfp=7 enable_auto_exposure=1 enable_distortion_correction=0 shutter_time_min=11000 shutter_time_max=11000/' /etc/modprobe.d/tier4-imx490.conf
+sed -i 's/options tier4_imx490 trigger_mode=0 enable_auto_exposure=1 enable_distortion_correction=1/options tier4_imx490 trigger_mode=1 fsync_mfp=7 enable_auto_exposure=1 enable_distortion_correction={{ distortion_correction }} shutter_time_min={{ exposure_time }} shutter_time_max={{ exposure_time }}/' /etc/modprobe.d/tier4-imx490.conf
 
 systemctl disable camera-driver-installer.service
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR makes TIER IV's camera settings, like `enable_distortion_correction` and `shutte_time_(min|max)`, configurable via ansilbe variables to add a capability of flexible settings. 

https://tier4.atlassian.net/browse/RT1-11053

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
