### PR TITLE
feat(autoware_system_monitor): build system_monitor on perception ecu

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -49,6 +49,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/image_transport_plugins.git
     version: foxy-devel
+  autoware/autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: 87fc41f07bc7054978ebedbfd30d5f88d18eddce
   # build dependencies
   cudnn_cmake_module:
     type: git

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ fi
 
 colcon build \
     --symlink-install --cmake-force-configure \
-    --packages-up-to edge_auto_jetson_launch \
+    --packages-up-to edge_auto_jetson_launch autoware_system_monitor \
     --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-w" -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=87 -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DBUILD_TESTING=OFF \
     -DPython3_EXECUTABLE="$(which python3)" \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5


### PR DESCRIPTION
## Description

This PR will build system_monitor on Perception ECUs, and the changes are the same as https://github.com/tier4/edge-auto-jetson.x2/pull/12

Since the repository used in pilot-auto.x2 has changed, a new commit is being made here.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Has passed testing on the bench environment.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

n/a

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
