### PR TITLE
feat: use variable for perception startup service template path

### DIFF
--- a/ansible/roles/perception_application/defaults/main.yaml
+++ b/ansible/roles/perception_application/defaults/main.yaml
@@ -6,4 +6,5 @@ perception_application_edge_auto_version: feat/v4.2/bsp36.4
 # perception_application_edge_auto_version: beta/v4.1.0
 perception_application_native_built_ros: false # true: native built, false: apt install
 perception_application_service_run_templates_file: run.sh.x2.j2 # run.sh.x2.j2
+perception_startup_service_template: perception-startup.service.j2
 video_num: 2

--- a/ansible/roles/perception_application/tasks/system_service.yaml
+++ b/ansible/roles/perception_application/tasks/system_service.yaml
@@ -26,7 +26,7 @@
 
 - name: Install perception startup service file
   ansible.builtin.template:
-    src: perception-startup.service.j2
+    src: "{{ perception_startup_service_template }}"
     dest: /etc/systemd/system/perception-startup.service
     mode: 0755
   become: true


### PR DESCRIPTION
## Description
Add an Ansible variable to set a template of perception_startup.service
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
