### PR TITLE
feat: manually add tf2-ros

### DIFF
--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -171,6 +171,7 @@
       - ros-{{ ros_distro }}-grid-map
       - ros-{{ ros_distro }}-filters
       - ros-{{ ros_distro }}-nav2-msgs
+      - ros-{{ ros_distro }}-tf2-ros
       - ros-{{ ros_distro }}-tf2-eigen
       - ros-{{ ros_distro }}-ament-cmake-clang-format
       - ros-{{ ros_distro }}-rmw-cyclonedds-cpp


### PR DESCRIPTION
## Description

Not installing tf2-ros manually gives build failure for autoware_tensorrt_yolox. `<depends>tf2-ros</depends>` passes fine, but tf2_ros headers are not includable. Add this for apt install list.

https://github.com/tier4/autoware_universe/tree/v0.60.0/perception/autoware_tensorrt_yolox

## Tests performed

I have built https://github.com/tier4/edge-auto-jetson/pkgs/container/edge-auto-jetson%2Fbase-image/619547336?tag=v0.48-tf2-ros-resolution from this branch, and built perception ECU image without `apt install ros-humble-tf2-ros` otherwise. The build succeeds.

https://evaluation.tier4.jp/evaluation/reports/a979f0e4-c2d8-5f43-88ea-dc943e74efbe?project_id=x2_dev

## Effects on system behavior

Prevent build failure from unfound tf2-ros headers.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
