### PR TITLE
fix: correct file path for ansible-galaxy-requirements.yaml

### DIFF
--- a/docker/edge-auto/Dockerfile.bi
+++ b/docker/edge-auto/Dockerfile.bi
@@ -19,7 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-ins
   && rm -rf /var/lib/apt/lists/*
 
 ## Copy files
-COPY ansible-galaxy-requirements.yaml /autoware/
+COPY .ansible-galaxy-requirements.yaml /autoware/
 COPY ansible/ /autoware/ansible/
 WORKDIR /autoware
 RUN ls /autoware


### PR DESCRIPTION
## Description
fix correct file path for ansible-galaxy-requirements.yaml

build failed action: https://github.com/tier4/edge-auto-jetson/actions/runs/21050888773, https://github.com/tier4/edge-auto-jetson/actions/runs/23233905672

## Tests performed
Confirmed base_image creation on v0.56 branch
https://github.com/tier4/edge-auto-jetson/actions/runs/23525840352
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
