### PR TITLE
fix: change variable name from ros_distro to rosdistro

### DIFF
--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -16,7 +16,7 @@ This role performs a complete ROS 2 installation including:
 
 | Name              | Required | Description                                                 |
 | ----------------- | -------- | ----------------------------------------------------------- |
-| rosdistro        | true     | The ROS 2 distribution to install (e.g., humble, iron)      |
+| rosdistro         | true     | The ROS 2 distribution to install (e.g., humble, iron)      |
 | installation_type | false    | Installation type: `desktop` (full) or `ros-base` (minimal) |
 
 ## Default Configuration

--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -16,7 +16,7 @@ This role performs a complete ROS 2 installation including:
 
 | Name              | Required | Description                                                 |
 | ----------------- | -------- | ----------------------------------------------------------- |
-| ros_distro        | true     | The ROS 2 distribution to install (e.g., humble, iron)      |
+| rosdistro        | true     | The ROS 2 distribution to install (e.g., humble, iron)      |
 | installation_type | false    | Installation type: `desktop` (full) or `ros-base` (minimal) |
 
 ## Default Configuration

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -123,10 +123,10 @@
     update_cache: yes
   when: opencv_removed.changed
 
-- name: Install ROS2 {{ ros_distro }}
+- name: Install ROS2 {{ rosdistro }}
   become: true
   ansible.builtin.apt:
-    name: ros-{{ ros_distro }}-{{ installation_type }}
+    name: ros-{{ rosdistro }}-{{ installation_type }}
     state: present
     update_cache: true
 
@@ -139,49 +139,49 @@
       - librange-v3-dev
       - v4l-utils
       - nlohmann-json3-dev
-      - ros-{{ ros_distro }}-launch-xml
-      - ros-{{ ros_distro }}-launch-yaml
-      - ros-{{ ros_distro }}-launch-testing
-      - ros-{{ ros_distro }}-launch-testing-ament-cmake
-      - ros-{{ ros_distro }}-demo-nodes-cpp
-      - ros-{{ ros_distro }}-demo-nodes-py
-      - ros-{{ ros_distro }}-example-interfaces
-      - ros-{{ ros_distro }}-camera-calibration-parsers
-      - ros-{{ ros_distro }}-camera-info-manager
-      - ros-{{ ros_distro }}-cv-bridge
-      - ros-{{ ros_distro }}-v4l2-camera
-      - ros-{{ ros_distro }}-vision-opencv
-      - ros-{{ ros_distro }}-libstatistics-collector
-      - ros-{{ ros_distro }}-geographic-msgs
-      - ros-{{ ros_distro }}-vision-msgs
-      - ros-{{ ros_distro }}-image-geometry
-      - ros-{{ ros_distro }}-image-pipeline
-      - ros-{{ ros_distro }}-image-transport
-      - ros-{{ ros_distro }}-compressed-image-transport
-      - ros-{{ ros_distro }}-compressed-depth-image-transport
-      - ros-{{ ros_distro }}-pcl-msgs
-      - ros-{{ ros_distro }}-perception-pcl
-      - ros-{{ ros_distro }}-logging-demo
-      - ros-{{ ros_distro }}-udp-msgs
-      - ros-{{ ros_distro }}-angles
-      - ros-{{ ros_distro }}-diagnostics
-      - ros-{{ ros_distro }}-tf-transformations
-      - ros-{{ ros_distro }}-mrt-cmake-modules
-      - ros-{{ ros_distro }}-gtest-vendor
-      - ros-{{ ros_distro }}-grid-map
-      - ros-{{ ros_distro }}-filters
-      - ros-{{ ros_distro }}-nav2-msgs
-      - ros-{{ ros_distro }}-tf2-ros
-      - ros-{{ ros_distro }}-tf2-eigen
-      - ros-{{ ros_distro }}-ament-cmake-clang-format
-      - ros-{{ ros_distro }}-rmw-cyclonedds-cpp
+      - ros-{{ rosdistro }}-launch-xml
+      - ros-{{ rosdistro }}-launch-yaml
+      - ros-{{ rosdistro }}-launch-testing
+      - ros-{{ rosdistro }}-launch-testing-ament-cmake
+      - ros-{{ rosdistro }}-demo-nodes-cpp
+      - ros-{{ rosdistro }}-demo-nodes-py
+      - ros-{{ rosdistro }}-example-interfaces
+      - ros-{{ rosdistro }}-camera-calibration-parsers
+      - ros-{{ rosdistro }}-camera-info-manager
+      - ros-{{ rosdistro }}-cv-bridge
+      - ros-{{ rosdistro }}-v4l2-camera
+      - ros-{{ rosdistro }}-vision-opencv
+      - ros-{{ rosdistro }}-libstatistics-collector
+      - ros-{{ rosdistro }}-geographic-msgs
+      - ros-{{ rosdistro }}-vision-msgs
+      - ros-{{ rosdistro }}-image-geometry
+      - ros-{{ rosdistro }}-image-pipeline
+      - ros-{{ rosdistro }}-image-transport
+      - ros-{{ rosdistro }}-compressed-image-transport
+      - ros-{{ rosdistro }}-compressed-depth-image-transport
+      - ros-{{ rosdistro }}-pcl-msgs
+      - ros-{{ rosdistro }}-perception-pcl
+      - ros-{{ rosdistro }}-logging-demo
+      - ros-{{ rosdistro }}-udp-msgs
+      - ros-{{ rosdistro }}-angles
+      - ros-{{ rosdistro }}-diagnostics
+      - ros-{{ rosdistro }}-tf-transformations
+      - ros-{{ rosdistro }}-mrt-cmake-modules
+      - ros-{{ rosdistro }}-gtest-vendor
+      - ros-{{ rosdistro }}-grid-map
+      - ros-{{ rosdistro }}-filters
+      - ros-{{ rosdistro }}-nav2-msgs
+      - ros-{{ rosdistro }}-tf2-ros
+      - ros-{{ rosdistro }}-tf2-eigen
+      - ros-{{ rosdistro }}-ament-cmake-clang-format
+      - ros-{{ rosdistro }}-rmw-cyclonedds-cpp
     state: present
     update_cache: yes
 
 - name: Add ROS2 setup to .bashrc
   ansible.builtin.lineinfile:
     dest: ~/.bashrc
-    line: source /opt/ros/{{ ros_distro }}/setup.bash
+    line: source /opt/ros/{{ rosdistro }}/setup.bash
     state: present
     create: true
     mode: 0644

--- a/ansible/roles/ros2_source/README.md
+++ b/ansible/roles/ros2_source/README.md
@@ -5,4 +5,4 @@ This role installs [ROS 2](https://docs.ros.org) under `/opt/ros`. Because apt b
 ## Inputs
 
 | Name | Required | Description |
-| ros_distro | true | The ROS distribution. Currently, only `humble` is supported. |
+| rosdistro | true | The ROS distribution. Currently, only `humble` is supported. |

--- a/ansible/roles/ros2_source/tasks/main.yaml
+++ b/ansible/roles/ros2_source/tasks/main.yaml
@@ -293,13 +293,13 @@
 
 - name: Check ROS build directory existence
   ansible.builtin.stat:
-    path: /opt/ros/{{ ros_distro }}
+    path: /opt/ros/{{ rosdistro }}
   register: ros_build_dir_exist
 
 - name: Build ROS
   block:
     - set_fact:
-        ros_base_dir: /opt/ros/{{ ros_distro }}
+        ros_base_dir: /opt/ros/{{ rosdistro }}
     - set_fact:
         ros_src_dir: "{{ ros_base_dir }}/src"
     - name: "{{ block_name }}: Create base directory"
@@ -313,14 +313,14 @@
         state: directory
       become: true
     - name: "{{ block_name }}: generate repository list using rosinstall_generator"
-      shell: rosinstall_generator --deps --rosdistro {{ ros_distro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl launch_pytest --exclude rmw_connextdds > /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
+      shell: rosinstall_generator --deps --rosdistro {{ rosdistro }} ros_base launch_xml launch_yaml launch_testing launch_testing_ament_cmake demo_nodes_cpp demo_nodes_py example_interfaces camera_calibration_parsers camera_info_manager cv_bridge vision_opencv vision_msgs image_geometry image_pipeline image_transport compressed_image_transport compressed_depth_image_transport pcl_msgs perception_pcl launch_pytest --exclude rmw_connextdds > /tmp/ros2.{{ rosdistro }}.ros_base.rosinstall
     - name: "{{ block_name }}: copy repository list to target ddirectory"
       ansible.builtin.copy:
-        src: /tmp/ros2.{{ ros_distro }}.ros_base.rosinstall
-        dest: "{{ ros_base_dir }}/ros2.{{ ros_distro }}.ros_base.rosinstall"
+        src: /tmp/ros2.{{ rosdistro }}.ros_base.rosinstall
+        dest: "{{ ros_base_dir }}/ros2.{{ rosdistro }}.ros_base.rosinstall"
       become: true
     - name: "{{ block_name }}: clone all repositories via vcs"
-      shell: vcs import src < ros2.{{ ros_distro }}.ros_base.rosinstall
+      shell: vcs import src < ros2.{{ rosdistro }}.ros_base.rosinstall
       args:
         chdir: "{{ ros_base_dir }}"
       become: true

--- a/docker/edge-auto/Dockerfile.bi
+++ b/docker/edge-auto/Dockerfile.bi
@@ -30,7 +30,7 @@ RUN mkdir -p ~/.ssh \
 
 ## Set up development environment
 RUN --mount=type=ssh ansible-playbook ansible/base_edge.yaml -e reload_system=no -e autoware_env_dir=/home/autoware \
-  -e ros_distro=${ROS_DISTRO}
+  -e rosdistro=${ROS_DISTRO}
 
 ## Clean up unnecessary files
 # hadolint ignore=DL3059


### PR DESCRIPTION
## Description
Standardize variable name from `ros_distro` to `rosdistro`

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/T4DEV-51184)
<!-- Write a brief description of this PR. -->

## Tests performed
Confirmed base_image creation [with this commit](https://github.com/tier4/edge-auto-jetson/pull/108).
https://github.com/tier4/edge-auto-jetson/actions/runs/23525840352

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
