### PR TITLE
feat: add tl_expected to extra_rosinstall_packages

### DIFF
--- a/ansible/roles/ros2_source_build/README.md
+++ b/ansible/roles/ros2_source_build/README.md
@@ -18,14 +18,14 @@ Builds [ROS 2](https://www.ros.org/) from source on Ubuntu 22.04 (e.g. Jetson), 
 
 ## Variables
 
-| Name                       | Required | Description |
-| -------------------------- | -------- | ----------- |
-| rosdistro                  | no       | ROS distro (e.g. `jazzy`). Default: `jazzy`. |
-| ros_variant                | no       | REP-2001 variant for the base source set (e.g. `ros_base`, `ros_core`). Default: `ros_base`. |
-| source_build_workspace_dir | no       | Workspace path (src, build, log). Default: `~/source_builds_ws`. |
-| extra_rosinstall_packages | no       | Extra ROS package names for `rosinstall_generator`. Package names like `cv_bridge`, not apt names like `ros-jazzy-cv-bridge`. If empty, the extra rosinstall/vcs step is skipped. |
-| extra_system_packages     | no       | Extra apt packages (e.g. libs, dev tools). Defaults include build tools and other deps for the default extra ROS packages (e.g. geographic, grid_map, perception_pcl). |
-| extra_python_packages     | no       | Extra pip packages. Defaults include empy, pytest, flake8 plugins, etc. |
+| Name                       | Required | Description                                                                                                                                                                       |
+| -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rosdistro                  | no       | ROS distro (e.g. `jazzy`). Default: `jazzy`.                                                                                                                                      |
+| ros_variant                | no       | REP-2001 variant for the base source set (e.g. `ros_base`, `ros_core`). Default: `ros_base`.                                                                                      |
+| source_build_workspace_dir | no       | Workspace path (src, build, log). Default: `~/source_builds_ws`.                                                                                                                  |
+| extra_rosinstall_packages  | no       | Extra ROS package names for `rosinstall_generator`. Package names like `cv_bridge`, not apt names like `ros-jazzy-cv-bridge`. If empty, the extra rosinstall/vcs step is skipped. |
+| extra_system_packages      | no       | Extra apt packages (e.g. libs, dev tools). Defaults include build tools and other deps for the default extra ROS packages (e.g. geographic, grid_map, perception_pcl).            |
+| extra_python_packages      | no       | Extra pip packages. Defaults include empy, pytest, flake8 plugins, etc.                                                                                                           |
 
 - **Workspace** (src, build, log): **`source_build_workspace_dir`** — created under the connecting user's home; no root. You can delete it after a successful build to save space.
 - **Install** (setup.bash, lib/, share/): **`/opt/ros/{{ rosdistro }}/`** — written by colcon with `--install-base` (same path as deb install).

--- a/ansible/roles/ros2_source_build/defaults/main.yaml
+++ b/ansible/roles/ros2_source_build/defaults/main.yaml
@@ -25,6 +25,7 @@ extra_rosinstall_packages:
   - filters
   - nav2_msgs
   - ffmpeg_image_transport_msgs # Required for accelerated_image_processor_ros
+  - tl_expected
   # - v4l2_camera # already included in edge-auto-jetson.repos
   # - image_pipeline # already included in edge-auto-jetson.repos
   # - mrt_cmake_modules # already included in edge-auto-jetson.repos

--- a/ansible/roles/ros2_source_build/defaults/main.yaml
+++ b/ansible/roles/ros2_source_build/defaults/main.yaml
@@ -1,6 +1,6 @@
 # ROS distro to build from source (e.g. jazzy for Ubuntu 22.04).
 rosdistro: jazzy
-ros_variant: ros_base  # detailed ros_variant is defined in https://www.ros.org/reps/rep-2001.html#jazzy-jalisco-may-2024-may-2029
+ros_variant: ros_base # detailed ros_variant is defined in https://www.ros.org/reps/rep-2001.html#jazzy-jalisco-may-2024-may-2029
 # Workspace directory (src, build, log). Install goes to /opt/ros/{{ rosdistro }} via --install-base.
 source_build_workspace_dir: "{{ ansible_env.HOME }}/source_builds_ws"
 


### PR DESCRIPTION
## Description
The perception feature development introduced a new required `<depends>tl_excepted</depends>`([URL](https://github.com/autowarefoundation/autoware_universe/pull/12794/changes#diff-c586ed7958a113658b4fa705213d4f7a45918be0c94edecf0bff56e1e30082b6R36)).  This PR adds the 
`<depends>tl_excepted</depends>` 　


## Ticket URL
https://tier4.atlassian.net/browse/T4DEV-55620