### PR TITLE
feat(base image): add extra rosinstall packages

### DIFF
--- a/ansible/roles/ros2_source_build/defaults/main.yaml
+++ b/ansible/roles/ros2_source_build/defaults/main.yaml
@@ -12,6 +12,7 @@ extra_rosinstall_packages:
   - vision_opencv
   - vision_msgs
   - image_geometry
+  - image_transport_plugins
   - image-transport
   - pcl_msgs
   - perception_pcl

--- a/ansible/roles/ros2_source_build/defaults/main.yaml
+++ b/ansible/roles/ros2_source_build/defaults/main.yaml
@@ -10,7 +10,6 @@ extra_rosinstall_packages:
   - camera_info_manager
   - cv_bridge
   - vision_opencv
-  - geographic_msgs
   - vision_msgs
   - image_geometry
   - image-transport
@@ -26,6 +25,11 @@ extra_rosinstall_packages:
   - nav2_msgs
   - ffmpeg_image_transport_msgs # Required for accelerated_image_processor_ros
   - tl_expected
+  - topic_tools
+  - lanelet2
+  - tensorrt_cmake_module
+  - geographic_info
+  - rclpy_message_converter
   # - v4l2_camera # already included in edge-auto-jetson.repos
   # - image_pipeline # already included in edge-auto-jetson.repos
   # - mrt_cmake_modules # already included in edge-auto-jetson.repos

--- a/ansible/roles/ros2_source_build/tasks/main.yaml
+++ b/ansible/roles/ros2_source_build/tasks/main.yaml
@@ -157,7 +157,7 @@
   become: true
   ansible.builtin.shell: >
     rosdep install --from-paths src --ignore-src -y
-    --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
+    --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers libopencv-imgproc-dev"
   args:
     chdir: "{{ source_build_workspace_dir }}"
   environment:


### PR DESCRIPTION
edge-auto-jetsonのautoware.reposで必要だったROS index登録パッケージをbase image作成時にビルドするようにする。対象は

```
  - image_transport_plugins
  - topic_tools
  - lanelet2
  - tensorrt_cmake_module
  - geographic_info
  - rclpy_message_converter
```
で、 `geographic_msgs` は `geographic_info` に含まれるので削除。

なお、image_transport_pluginsから `libopencv-imgproc-dev` 依存性が入るが、jetson imageにインストールできないためスキップ (当該run: https://github.com/tier4/edge-auto-jetson/actions/runs/30372497988/job/90322763226 )。スキップして作成されたbase imageでも運用上問題ない。

```
dmesg: read kernel buffer failed: Operation not permitted
```

***

背景・テストに関しては https://github.com/tier4/pilot-auto.x2/pull/5330 を参照(本PRブランチで作成したbase imageは既に使われている)